### PR TITLE
chore: bump to 0.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rive-react",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "React wrapper around the rive-js library",
   "main": "dist/index.js",
   "typings": "dist/types/index.d.ts",


### PR DESCRIPTION
Something went wrong with deployment due to wrong npm token