### PR TITLE
Add verticalAlign = top to canvas to prevent canvas growth on resize

### DIFF
--- a/src/hooks/useRive.tsx
+++ b/src/hooks/useRive.tsx
@@ -36,7 +36,7 @@ function RiveComponent({
       style={'className' in rest ? undefined : containerStyle}
       {...rest}
     >
-      <canvas ref={setCanvasRef} />
+      <canvas ref={setCanvasRef} style={{ verticalAlign: 'top' }} />
     </div>
   );
 }


### PR DESCRIPTION
Canvas by default is an inline element, and 4px are added under it between it and the div container. When a resize happens, we take the size of the outer div and apply it to the canvas so it also resizes. This works fine when the width/height is static (e.g 500px) but not when it's dynamic (e.g 100%), as the extra 4px is taken in to account each time. To prevent this extra 4px, you need to make the canvas element `display: 'block'` or `verticalAlign: 'top'`.  I've gone with `verticalAlign: 'top'`.

https://stackoverflow.com/questions/8600393/there-is-a-4px-gap-below-canvas-video-audio-elements-in-html5