### PR TITLE
Update: Adding build scripts to prepare for split of rive-react into 2 package derivatives for canvas and webgl

### DIFF
--- a/npm/rive-react-canvas/README.md
+++ b/npm/rive-react-canvas/README.md
@@ -1,0 +1,3 @@
+# rive-react-canvas
+
+Output for `rive-react` using the backing `@rive-app/canvas` JS runtime

--- a/npm/rive-react-webgl/README.md
+++ b/npm/rive-react-webgl/README.md
@@ -1,0 +1,3 @@
+# rive-react-webgl
+
+Output for `rive-react` using the backing `@rive-app/webgl` JS runtime

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Run the build and copy to the rive-react-webgl build for npm release
+npm run build
+cp -r ./dist ./npm/rive-react-webgl
+cp -r ./dist ./npm/rive-react-canvas
+
+echo Replacing the webgl with canvas references
+pushd ./npm/rive-react-canvas/dist
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  find . -type f -name "*.ts" -print0 | xargs -0 sed -i '' -e 's/@rive-app\/webgl/@rive-app\/canvas/g'
+  find . -type f -name "*.js" -print0 | xargs -0 sed -i '' -e 's/@rive-app\/webgl/@rive-app\/canvas/g'
+else
+  find . -type f -name "*.ts" -print0 | xargs -0 sed -i -e 's/@rive-app\/webgl/@rive-app\/canvas/g'
+  find . -type f -name "*.js" -print0 | xargs -0 sed -i -e 's/@rive-app\/webgl/@rive-app\/canvas/g'
+fi
+popd

--- a/scripts/bump_all_versions.sh
+++ b/scripts/bump_all_versions.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Bump the version number of every npm module in the npm folder.
+for dir in ./npm/*; do
+    pushd $dir > /dev/null
+    repo_name=`echo $dir | sed 's:.*/::' | sed 's/_/-/g'`
+    echo Bumping version of $repo_name
+    ../../scripts/bump_version.sh $repo_name
+    popd > /dev/null
+done

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Bumps the version of a single npm module found in the current working
+# directory. Call bump_version.sh from the path with package.json in it.
+
+set -e
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+NPM_VERSIONS=`npm show rive-react versions`
+node $SCRIPT_DIR/nextVersion.js "$NPM_VERSIONS" `pwd`

--- a/scripts/nextVersion.js
+++ b/scripts/nextVersion.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = process.argv[3];
+const package = require(path + '/package.json');
+let versions = JSON.parse(process.argv[2].trim().replace(/\'/g, '"'));
+const current = package.version;
+// Don't work with alpha/beta/rc tags, maybe a better regex here?
+versions = versions.filter((ver) => {
+  return !/[a-zA-Z]/.test(ver);
+});
+
+const latest = versions[versions.length - 1];
+
+// Returns -1 if first is less than second, 1 if first is greater than second, otherwise 0 if equal.
+function compareVersion(first, second) {
+  // Assumption: only numbers in our versions.
+  const firstParts = first.split('.').map((value) => parseInt(value));
+  const secondParts = second.split('.').map((value) => parseInt(value));
+
+  for (let i = 0; i < firstParts.length; i++) {
+    if (secondParts.length === i) {
+      return 1;
+    }
+
+    if (firstParts[i] < secondParts[i]) {
+      return -1;
+    } else if (firstParts[i] > secondParts[i]) {
+      return 1;
+    }
+  }
+
+  if (firstParts.length !== secondParts.length) {
+    return -1;
+  }
+
+  return 0;
+}
+
+if (compareVersion(current, latest) <= 0) {
+  const parts = latest.split('.').map((value) => parseInt(value));
+  // TODO: Need to make this smarter, because the semver can change on rive-react
+  parts[parts.length - 1] = parts[parts.length - 1] + 1;
+  package.version = parts.join('.');
+  fs.writeFileSync(path + '/package.json', JSON.stringify(package, null, 2));
+}

--- a/scripts/publish_all.sh
+++ b/scripts/publish_all.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Bump the version number of every npm module in the npm folder.
+for dir in ./npm/*; do
+    pushd $dir > /dev/null
+    echo Publishing `echo $dir | sed 's:.*/::'`
+    npm publish $@
+    popd > /dev/null
+done

--- a/scripts/setup_all_packages.sh
+++ b/scripts/setup_all_packages.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+echo Copying package.json to rive-react npm package folders
+
+cp package.json npm/rive-react-canvas
+cp package.json npm/rive-react-webgl
+
+# Bump the version number of every npm module in the npm folder.
+for dir in ./npm/*; do
+    echo $dir
+    pushd $dir > /dev/null
+    echo $dir
+    repo_name=`echo $dir | sed 's:.*/::' | sed 's/_/-/g'`
+    echo Setting package.json on npm packages
+    echo $repo_name
+    ../../scripts/setup_package.sh $repo_name
+    echo Finished setting up package.json
+    popd > /dev/null
+done
+

--- a/scripts/setup_package.sh
+++ b/scripts/setup_package.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# Setup the package.json for a given npm module
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+node $SCRIPT_DIR/trimPackageJson.js `pwd` "$1"

--- a/scripts/trimPackageJson.js
+++ b/scripts/trimPackageJson.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = process.argv[2];
+const npmPackageSplit = process.argv[3].split('-');
+const renderer = npmPackageSplit[npmPackageSplit.length - 1];
+const package = require(path + '/package.json');
+
+function trimNpmPackage() {
+  package.name = `${package.name}-${renderer}`;
+  package.description = `React wrapper around the @rive-app/${renderer} library`;
+  const webDependencyName = `@rive-app/${renderer}`;
+  const canvasDep = package.dependencies[webDependencyName];
+  package.dependencies = {
+    [webDependencyName]: canvasDep,
+  };
+  delete package.devDependencies;
+  delete package.scripts;
+  fs.writeFileSync(path + '/package.json', JSON.stringify(package, null, 2));
+}
+
+if (renderer) {
+  trimNpmPackage();
+}


### PR DESCRIPTION
Not running these scripts yet in GH action workflows, just want to get some feedback early here on the strategy and merge the scripts early if we go this route. The thinking is:

With the assumption:
- `rive-react` will have `@rive-app/canvas` (what it is today) and `@rive-app/webgl` installed as deps
- `rive-react` will have changed to reference `webgl` runtime instead of `canvas`

Order of ops:
- Run `build.sh` which creates the build, copies the dist into `npm/rive-react-canvas` and `npm/rive-react-webgl` (new sub-packages), and changes references in `rive-react-canvas` builds of `@rive-app/webgl` to `@rive-app/canvas` via sed
- Run `setup_all_packages.sh` which copies the package.json in `rive-react` to the canvas and WebGL react packages in the `npm` folder, trims out most things but keeps `@rive-app/canvas` as a dep in `rive-react-canvas` and `@rive-app/webgl` as a dep in `rive-react-webgl`, both with peer deps of react; no scripts, devDeps, and changes the name of the package.json to their respective `npm` folders
- Run `bump_all_versions.sh` which is similar to the js/wasm runtime setup, in that it finds the latest version of `rive-react` and bumps up one patch version in the package jsons for `rive-react-canvas` and `rive-react-webgl`
- Run `publish_all.sh` which runs the publish on both the derived react packages, also similar to wasm setup

Concerns:
- Would be great to bump the derived react packages to the same version the `rive-react` package will, but the `release-it` tool has to run first, which I'm not sure we can wait on? Today I don't think it matters because I believe it just bumps by patch version
