### PR TITLE
Patch: Bump rive-cpp to fix DAG issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/webgl": "1.0.28"
+    "@rive-app/webgl": "1.0.30"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0"


### PR DESCRIPTION
Taking a downstream wasm/js fix