### PR TITLE
Feat: Add extra param to useStateMachineInput to set an initial value on the input when its loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ See our [examples](examples) folder for working examples of [Boolean](examples/s
 - `rive`: A `Rive` object. This is returned by the `useRive` hook.
 - `stateMachineName`: Name of the state machine.
 - `inputName`: Name of the state machine input.
+- `initialValue`: Initial value to set on a state machine input when it's loaded in, for number or boolean inputs.
 
 #### Return Value
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ See our [examples](examples) folder for working examples of [Boolean](examples/s
 - `rive`: A `Rive` object. This is returned by the `useRive` hook.
 - `stateMachineName`: Name of the state machine.
 - `inputName`: Name of the state machine input.
-- `initialValue`: Initial value to set on a state machine input when it's loaded in, for number or boolean inputs.
+- `initialValue`: Initial value to set on a state machine input when it's loaded in, for number or boolean inputs. **Note** that this may trigger any transitional animations between the initial state and any next states that depend on the input this `initialValue` is being set to. If this is problematic or conflicting for your case, we recommend setting the true initial value of the input on your state machine in the Rive editor. 
 
 #### Return Value
 

--- a/src/hooks/useStateMachineInput.ts
+++ b/src/hooks/useStateMachineInput.ts
@@ -12,7 +12,8 @@ import { Rive, StateMachineInput } from '@rive-app/webgl';
 export default function useStateMachineInput(
   rive: Rive | null,
   stateMachineName?: string,
-  inputName?: string
+  inputName?: string,
+  initialValue?: number | boolean
 ) {
   const [input, setInput] = useState<StateMachineInput | null>(null);
 
@@ -25,6 +26,9 @@ export default function useStateMachineInput(
       const inputs = rive.stateMachineInputs(stateMachineName);
       if (inputs) {
         const selectedInput = inputs.find((input) => input.name === inputName);
+        if (initialValue !== undefined && selectedInput) {
+          selectedInput.value = initialValue;
+        }
         setInput(selectedInput || null);
       }
     } else {

--- a/test/useStateMachine.test.tsx
+++ b/test/useStateMachine.test.tsx
@@ -1,0 +1,107 @@
+import { mocked } from 'jest-mock';
+import { renderHook } from '@testing-library/react-hooks';
+
+import useStateMachineInput from '../src/hooks/useStateMachineInput';
+import {Rive, StateMachineInput} from '@rive-app/webgl';
+
+jest.mock('@rive-app/webgl', () => ({
+  Rive: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    stop: jest.fn(),
+  })),
+  Layout: jest.fn(),
+  Fit: {
+    Cover: 'cover',
+  },
+  Alignment: {
+    Center: 'center',
+  },
+  EventType: {
+    Load: 'load',
+  },
+  StateMachineInputType: {
+    Number: 1,
+    Boolean: 2,
+    Trigger: 3,
+  },
+}));
+
+describe('useStateMachineInput', () => {
+  it('returns null if there is null rive object passed', () => {
+    const { result } = renderHook(() => useStateMachineInput(null));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null if there is no state machine name', () => {
+    const riveMock = {};
+    mocked(Rive).mockImplementation(() => riveMock as Rive);
+
+    const { result } = renderHook(() => useStateMachineInput(riveMock as Rive, '', 'testInput'));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null if there is no state machine input name', () => {
+    const riveMock = {};
+    mocked(Rive).mockImplementation(() => riveMock as Rive);
+
+    const { result } = renderHook(() => useStateMachineInput(riveMock as Rive, 'smName', ''));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null if there are no inputs for the state machine', () => {
+    const riveMock = {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      stateMachineInputs: (_: string) => [] as StateMachineInput[],
+    };
+    mocked(Rive).mockImplementation(() => riveMock as Rive);
+
+    const { result } = renderHook(() => useStateMachineInput(riveMock as Rive, 'smName', ''));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null if the input has no association to the inputs of the state machine', () => {
+    const smInput = {
+      name: 'boolInput',
+    } as StateMachineInput;
+    const riveMock = {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      stateMachineInputs: (_: string) => [smInput] as StateMachineInput[],
+    };
+    mocked(Rive).mockImplementation(() => riveMock as Rive);
+
+    const { result } = renderHook(() => useStateMachineInput(riveMock as Rive, 'smName', 'numInput'));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns a selected input if the input requested is part of the state machine', () => {
+    const smInput = {
+      name: 'boolInput',
+    } as StateMachineInput;
+    const riveMock = {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      stateMachineInputs: (_: string) => [smInput] as StateMachineInput[],
+    };
+    mocked(Rive).mockImplementation(() => riveMock as Rive);
+
+    const { result } = renderHook(() => useStateMachineInput(riveMock as Rive, 'smName', 'boolInput'));
+    expect(result.current).toBe(smInput);
+  });
+
+  it('returns a selected input with an initial value if the input requested is part of the state machine', () => {
+    const smInput = {
+      name: 'boolInput',
+      value: false,
+    } as StateMachineInput;
+    const riveMock = {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      stateMachineInputs: (_: string) => [smInput] as StateMachineInput[],
+    };
+    mocked(Rive).mockImplementation(() => riveMock as Rive);
+
+    const { result } = renderHook(() => useStateMachineInput(riveMock as Rive, 'smName', 'boolInput', true));
+    expect(result.current).toStrictEqual({
+      ...smInput,
+      value: true,
+    });
+  });
+});


### PR DESCRIPTION
Wasn't a super straightforward way to set an initial value on a state machine input when its loaded in. This should provide a simpler way to set one.

Also added tests for the `useStateMachineInput` hook. 