### PR TITLE
Update: Adding build scripts to prepare for split of rive-react into 2 package derivatives for canvas and webgl

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,31 @@ on:
     branches:
       - main
 jobs:
+  determine_version:
+    name: Determine the next build version
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.echo_version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ./
+      - id: determine_version
+        name: Get Version
+        run: npm run release -- --ci --release-version | tail -n 1 > RELEASE_VERSION
+        working-directory: ./
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+      - id: echo_version
+        run: echo "::set-output name=version::$(cat ./RELEASE_VERSION)"
+  
   merge_job:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    needs: [determine_version]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -33,4 +55,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
-        run: npm run release
+        run: npm run release -- --ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - main
 jobs:
   merge_job:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm i --save rive-react
 
 _Note: This library is using React hooks so the minimum version required for both react and react-dom is 16.8.0._
 
-### Migrating from v 0.0.x to 1.x.x
+### Migrating from version 0.0.x to 1.x.x
 
 Starting in v 1.0.0, we've migrated from wrapping around the `@rive-app/canvas` runtime (which uses the `CanvasRendereringContext2D` renderer) to the `@rive-app/webgl` runtime (which uses the WebGL renderer). The high-level API doesn't require any change to upgrade, but there are some notes to consider about the backing renderer.
 
@@ -45,6 +45,10 @@ return (
   <Rive src="foo.riv" useOffscreenRenderer={false} />
 );
 ```
+
+### Migrating from version 1.x.x to 2.x.x
+
+In most cases, you may be able to migrate safely. We are mainly enabling `rive-react` to work with both backing renderers `@rive-app/webgl` and `@rive-app/canvas`, such that you can use either `@rive-app/react-canvas` or `@rive-app/react-webgl` as the dependency in your React applications. Another change that is mostly internal is that by default, `rive-react` will now use `@rive-app/canvas` (as opposed to `@rive-app/webgl`) to wrap around, as it currently yields the fastest performance across devices. Therefore, **we recommend installing `@rive-app/react-canvas` in your applicaions**. However, if you need a WebGL backing renderer, you may want to use `@rive-app/react-webgl`.
 
 ## Usage
 

--- a/npm/react-canvas/README.md
+++ b/npm/react-canvas/README.md
@@ -1,3 +1,3 @@
-# rive-react-canvas
+# @rive-app/react-canvas
 
 Output for `rive-react` using the backing `@rive-app/canvas` JS runtime

--- a/npm/react-webgl/README.md
+++ b/npm/react-webgl/README.md
@@ -1,3 +1,3 @@
-# rive-react-webgl
+# @rive-app/react-webgl
 
 Output for `rive-react` using the backing `@rive-app/webgl` JS runtime

--- a/npm/rive-react-canvas/README.md
+++ b/npm/rive-react-canvas/README.md
@@ -1,0 +1,3 @@
+# rive-react-canvas
+
+Output for `rive-react` using the backing `@rive-app/canvas` JS runtime

--- a/npm/rive-react-webgl/README.md
+++ b/npm/rive-react-webgl/README.md
@@ -1,0 +1,3 @@
+# rive-react-webgl
+
+Output for `rive-react` using the backing `@rive-app/webgl` JS runtime

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/webgl": "1.0.39"
+    "@rive-app/canvas": "1.0.44",
+    "@rive-app/webgl": "1.0.41"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-# Run the build and copy to each react-variant build for npm release
-npm run build
+# Copy the build to each react-variant build for npm release
 cp -r ./dist ./npm/react-webgl
 cp -r ./dist ./npm/react-canvas
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Run the build and copy to the rive-react-webgl build for npm release
+npm run build
+cp -r ./dist ./npm/rive-react-webgl
+cp -r ./dist ./npm/rive-react-canvas
+
+echo Replacing the webgl with canvas references
+pushd ./npm/rive-react-canvas/dist
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  find . -type f -name "*.ts" -print0 | xargs -0 sed -i '' -e 's/@rive-app\/webgl/@rive-app\/canvas/g'
+  find . -type f -name "*.js" -print0 | xargs -0 sed -i '' -e 's/@rive-app\/webgl/@rive-app\/canvas/g'
+else
+  find . -type f -name "*.ts" -print0 | xargs -0 sed -i -e 's/@rive-app\/webgl/@rive-app\/canvas/g'
+  find . -type f -name "*.js" -print0 | xargs -0 sed -i -e 's/@rive-app\/webgl/@rive-app\/canvas/g'
+fi
+popd

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,18 +2,18 @@
 
 set -e
 
-# Run the build and copy to the rive-react-webgl build for npm release
+# Run the build and copy to each react-variant build for npm release
 npm run build
-cp -r ./dist ./npm/rive-react-webgl
-cp -r ./dist ./npm/rive-react-canvas
+cp -r ./dist ./npm/react-webgl
+cp -r ./dist ./npm/react-canvas
 
-echo Replacing the webgl with canvas references
-pushd ./npm/rive-react-canvas/dist
+echo "Replacing the canvas with webgl references in react-webgl"
+pushd ./npm/react-webgl/dist
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  find . -type f -name "*.ts" -print0 | xargs -0 sed -i '' -e 's/@rive-app\/webgl/@rive-app\/canvas/g'
-  find . -type f -name "*.js" -print0 | xargs -0 sed -i '' -e 's/@rive-app\/webgl/@rive-app\/canvas/g'
+  find . -type f -name "*.ts" -print0 | xargs -0 sed -i '' -e 's/@rive-app\/canvas/@rive-app\/webgl/g'
+  find . -type f -name "*.js" -print0 | xargs -0 sed -i '' -e 's/@rive-app\/canvas/@rive-app\/webgl/g'
 else
-  find . -type f -name "*.ts" -print0 | xargs -0 sed -i -e 's/@rive-app\/webgl/@rive-app\/canvas/g'
-  find . -type f -name "*.js" -print0 | xargs -0 sed -i -e 's/@rive-app\/webgl/@rive-app\/canvas/g'
+  find . -type f -name "*.ts" -print0 | xargs -0 sed -i -e 's/@rive-app\/canvas/@rive-app\/webgl/g'
+  find . -type f -name "*.js" -print0 | xargs -0 sed -i -e 's/@rive-app\/canvas/@rive-app\/webgl/g'
 fi
 popd

--- a/scripts/bump_all_versions.sh
+++ b/scripts/bump_all_versions.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Bump the version number of every npm module in the npm folder.
+for dir in ./npm/*; do
+    pushd $dir > /dev/null
+    repo_name=`echo $dir | sed 's:.*/::' | sed 's/_/-/g'`
+    echo Bumping version of $repo_name
+    ../../scripts/bump_version.sh $repo_name
+    popd > /dev/null
+done

--- a/scripts/bump_all_versions.sh
+++ b/scripts/bump_all_versions.sh
@@ -6,6 +6,6 @@ for dir in ./npm/*; do
     pushd $dir > /dev/null
     repo_name=`echo $dir | sed 's:.*/::' | sed 's/_/-/g'`
     echo Bumping version of $repo_name
-    ../../scripts/bump_version.sh $repo_name
+    ../../scripts/bump_version.sh $repo_name $RELEASE_VERSION
     popd > /dev/null
 done

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -5,5 +5,5 @@
 
 set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-NPM_VERSIONS=`npm show rive-react versions`
-node $SCRIPT_DIR/nextVersion.js "$NPM_VERSIONS" `pwd`
+# RELEASE_VERSION will come from an env variable passed in from the GH action workflow
+node $SCRIPT_DIR/nextVersion.js "$RELEASE_VERSION" `pwd`

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Bumps the version of a single npm module found in the current working
+# directory. Call bump_version.sh from the path with package.json in it.
+
+set -e
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+NPM_VERSIONS=`npm show rive-react versions`
+node $SCRIPT_DIR/nextVersion.js "$NPM_VERSIONS" `pwd`

--- a/scripts/nextVersion.js
+++ b/scripts/nextVersion.js
@@ -1,14 +1,12 @@
 const fs = require('fs');
 const path = process.argv[3];
 const package = require(path + '/package.json');
-let versions = JSON.parse(process.argv[2].trim().replace(/\'/g, '"'));
-const current = package.version;
-// Don't work with alpha/beta/rc tags, maybe a better regex here?
-versions = versions.filter((ver) => {
-  return !/[a-zA-Z]/.test(ver);
-});
+const currentVersion = package.version;
+const nextVersion = process.argv[2].trim().replace(/\'/g, '"');
 
-const latest = versions[versions.length - 1];
+if (!nextVersion || nextVersion === currentVersion) {
+  throw new Error('Next version is not defined or is a version that already exists');
+}
 
 // Returns -1 if first is less than second, 1 if first is greater than second, otherwise 0 if equal.
 function compareVersion(first, second) {
@@ -35,10 +33,7 @@ function compareVersion(first, second) {
   return 0;
 }
 
-if (compareVersion(current, latest) <= 0) {
-  const parts = latest.split('.').map((value) => parseInt(value));
-  // TODO: Need to make this smarter, because the semver can change on rive-react
-  parts[parts.length - 1] = parts[parts.length - 1] + 1;
-  package.version = parts.join('.');
+if (compareVersion(currentVersion, nextVersion) <= 0) {
+  package.version = nextVersion;
   fs.writeFileSync(path + '/package.json', JSON.stringify(package, null, 2));
 }

--- a/scripts/nextVersion.js
+++ b/scripts/nextVersion.js
@@ -14,22 +14,16 @@ function compareVersion(first, second) {
   const firstParts = first.split('.').map((value) => parseInt(value));
   const secondParts = second.split('.').map((value) => parseInt(value));
 
-  for (let i = 0; i < firstParts.length; i++) {
-    if (secondParts.length === i) {
-      return 1;
+  for (let i = 0; i < Math.max(firstParts.length, secondParts.length); i++) {
+    const first = i < firstParts.length ? firstParts[i] : 0;
+    const second = i < secondParts.length ? secondParts[i] : 0;
+    if (first < second) {
+        return -1;
     }
-
-    if (firstParts[i] < secondParts[i]) {
-      return -1;
-    } else if (firstParts[i] > secondParts[i]) {
-      return 1;
+    if (second < first) {
+        return 1;
     }
   }
-
-  if (firstParts.length !== secondParts.length) {
-    return -1;
-  }
-
   return 0;
 }
 

--- a/scripts/nextVersion.js
+++ b/scripts/nextVersion.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = process.argv[3];
+const package = require(path + '/package.json');
+let versions = JSON.parse(process.argv[2].trim().replace(/\'/g, '"'));
+const current = package.version;
+// Don't work with alpha/beta/rc tags, maybe a better regex here?
+versions = versions.filter((ver) => {
+  return !/[a-zA-Z]/.test(ver);
+});
+
+const latest = versions[versions.length - 1];
+
+// Returns -1 if first is less than second, 1 if first is greater than second, otherwise 0 if equal.
+function compareVersion(first, second) {
+  // Assumption: only numbers in our versions.
+  const firstParts = first.split('.').map((value) => parseInt(value));
+  const secondParts = second.split('.').map((value) => parseInt(value));
+
+  for (let i = 0; i < firstParts.length; i++) {
+    if (secondParts.length === i) {
+      return 1;
+    }
+
+    if (firstParts[i] < secondParts[i]) {
+      return -1;
+    } else if (firstParts[i] > secondParts[i]) {
+      return 1;
+    }
+  }
+
+  if (firstParts.length !== secondParts.length) {
+    return -1;
+  }
+
+  return 0;
+}
+
+if (compareVersion(current, latest) <= 0) {
+  const parts = latest.split('.').map((value) => parseInt(value));
+  // TODO: Need to make this smarter, because the semver can change on rive-react
+  parts[parts.length - 1] = parts[parts.length - 1] + 1;
+  package.version = parts.join('.');
+  fs.writeFileSync(path + '/package.json', JSON.stringify(package, null, 2));
+}

--- a/scripts/publish_all.sh
+++ b/scripts/publish_all.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Bump the version number of every npm module in the npm folder.
+for dir in ./npm/*; do
+    pushd $dir > /dev/null
+    echo Publishing `echo $dir | sed 's:.*/::'`
+    npm publish $@
+    popd > /dev/null
+done

--- a/scripts/publish_all.sh
+++ b/scripts/publish_all.sh
@@ -5,6 +5,6 @@ set -e
 for dir in ./npm/*; do
     pushd $dir > /dev/null
     echo Publishing `echo $dir | sed 's:.*/::'`
-    npm publish $@
+    npm publish --access public
     popd > /dev/null
 done

--- a/scripts/setup_all_packages.sh
+++ b/scripts/setup_all_packages.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 
-echo Copying package.json to rive-react npm package folders
+echo "Copying package.json to rive-react npm package folders"
 
-cp package.json npm/rive-react-canvas
-cp package.json npm/rive-react-webgl
+cp package.json npm/react-canvas
+cp package.json npm/react-webgl
 
 # Bump the version number of every npm module in the npm folder.
 for dir in ./npm/*; do

--- a/scripts/setup_all_packages.sh
+++ b/scripts/setup_all_packages.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+echo Copying package.json to rive-react npm package folders
+
+cp package.json npm/rive-react-canvas
+cp package.json npm/rive-react-webgl
+
+# Bump the version number of every npm module in the npm folder.
+for dir in ./npm/*; do
+    echo $dir
+    pushd $dir > /dev/null
+    echo $dir
+    repo_name=`echo $dir | sed 's:.*/::' | sed 's/_/-/g'`
+    echo Setting package.json on npm packages
+    echo $repo_name
+    ../../scripts/setup_package.sh $repo_name
+    echo Finished setting up package.json
+    popd > /dev/null
+done
+

--- a/scripts/setup_package.sh
+++ b/scripts/setup_package.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# Setup the package.json for a given npm module
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+node $SCRIPT_DIR/trimPackageJson.js `pwd` "$1"

--- a/scripts/trimPackageJson.js
+++ b/scripts/trimPackageJson.js
@@ -5,7 +5,7 @@ const renderer = npmPackageSplit[npmPackageSplit.length - 1];
 const package = require(path + '/package.json');
 
 function trimNpmPackage() {
-  package.name = `${package.name}-${renderer}`;
+  package.name = `@rive-app/react-${renderer}`;
   package.description = `React wrapper around the @rive-app/${renderer} library`;
   const webDependencyName = `@rive-app/${renderer}`;
   const canvasDep = package.dependencies[webDependencyName];

--- a/scripts/trimPackageJson.js
+++ b/scripts/trimPackageJson.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = process.argv[2];
+const npmPackageSplit = process.argv[3].split('-');
+const renderer = npmPackageSplit[npmPackageSplit.length - 1];
+const package = require(path + '/package.json');
+
+function trimNpmPackage() {
+  package.name = `${package.name}-${renderer}`;
+  package.description = `React wrapper around the @rive-app/${renderer} library`;
+  const webDependencyName = `@rive-app/${renderer}`;
+  const canvasDep = package.dependencies[webDependencyName];
+  package.dependencies = {
+    [webDependencyName]: canvasDep,
+  };
+  delete package.devDependencies;
+  delete package.scripts;
+  fs.writeFileSync(path + '/package.json', JSON.stringify(package, null, 2));
+}
+
+if (renderer) {
+  trimNpmPackage();
+}

--- a/src/components/Rive.tsx
+++ b/src/components/Rive.tsx
@@ -1,4 +1,4 @@
-import { Layout } from '@rive-app/webgl';
+import { Layout } from '@rive-app/canvas';
 import React, { ComponentProps } from 'react';
 import useRive from '../hooks/useRive';
 

--- a/src/hooks/useRive.tsx
+++ b/src/hooks/useRive.tsx
@@ -6,7 +6,7 @@ import React, {
   ComponentProps,
   RefCallback,
 } from 'react';
-import { Rive, EventType } from '@rive-app/webgl';
+import { Rive, EventType } from '@rive-app/canvas';
 import {
   UseRiveParameters,
   UseRiveOptions,

--- a/src/hooks/useStateMachineInput.ts
+++ b/src/hooks/useStateMachineInput.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Rive, StateMachineInput } from '@rive-app/webgl';
+import { Rive, StateMachineInput } from '@rive-app/canvas';
 
 /**
  * Custom hook for fetching a stateMachine input from a rive file.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,4 @@ import useStateMachineInput from './hooks/useStateMachineInput';
 export default Rive;
 export { useRive, useStateMachineInput };
 export { RiveState, UseRiveParameters, UseRiveOptions } from './types';
-export * from '@rive-app/webgl';
+export * from '@rive-app/canvas';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { RefCallback, ComponentProps } from 'react';
-import { Rive, RiveParameters } from '@rive-app/webgl';
+import { Rive, RiveParameters } from '@rive-app/canvas';
 
 export type UseRiveParameters = Partial<Omit<RiveParameters, 'canvas'>> | null;
 

--- a/test/useRive.test.tsx
+++ b/test/useRive.test.tsx
@@ -2,9 +2,9 @@ import { mocked } from 'jest-mock';
 import { renderHook, act } from '@testing-library/react-hooks';
 
 import useRive from '../src/hooks/useRive';
-import * as rive from '@rive-app/webgl';
+import * as rive from '@rive-app/canvas';
 
-jest.mock('@rive-app/webgl', () => ({
+jest.mock('@rive-app/canvas', () => ({
   Rive: jest.fn().mockImplementation(() => ({
     on: jest.fn(),
     stop: jest.fn(),

--- a/test/useStateMachine.test.tsx
+++ b/test/useStateMachine.test.tsx
@@ -2,9 +2,9 @@ import { mocked } from 'jest-mock';
 import { renderHook } from '@testing-library/react-hooks';
 
 import useStateMachineInput from '../src/hooks/useStateMachineInput';
-import {Rive, StateMachineInput} from '@rive-app/webgl';
+import {Rive, StateMachineInput} from '@rive-app/canvas';
 
-jest.mock('@rive-app/webgl', () => ({
+jest.mock('@rive-app/canvas', () => ({
   Rive: jest.fn().mockImplementation(() => ({
     on: jest.fn(),
     stop: jest.fn(),


### PR DESCRIPTION
## Summary
Today, the React runtime wraps around only one dependency, either canvas or WebGL, and we wrap around WebGL currently since v1.0.0. However, we'll want to support both a canvas and WebGL renderer to be able to iterate on performance and developer experience through React. To do that, we'll want to do a similar strategy to the `rive-js` old dependency, and split into `@rive-app/react-canvas` and `@rive-app/react-webgl`. These scripts should help get us there. Below is an explanation on the strategy we can run through Github Actions.


## Scripts
Not running these scripts yet in GH action workflows for this PR, just want to get some feedback early here on the strategy and merge the scripts early if we go this route. The thinking is:

With the assumption:
- `rive-react` will have `@rive-app/canvas` and `@rive-app/webgl` (what it is today) installed as deps
- `rive-react` will have changed to reference `canvas` runtime instead of `webgl` for now, as performance is currently better on canvas

Order of ops:
- Run `build.sh` which creates the build, copies the dist into `npm/react-canvas` and `npm/react-webgl` (new sub-packages), and changes references in `@rive-app/react-webgl` builds of `@rive-app/canvas` to `@rive-app/webgl` via sed
- Run `setup_all_packages.sh` which copies the package.json in `rive-react` to the canvas and WebGL react packages in the `npm` folder, trims out most things but keeps `@rive-app/canvas` as a dep in `@rive-app/react-canvas` and `@rive-app/webgl` as a dep in `@rive-app/react-webgl`, both with peer deps of react; no scripts, devDeps, and changes the name of the package.json to their respective `npm` folders
- Run `bump_all_versions.sh` which is similar to the js/wasm runtime setup, in that it finds the latest version of `rive-react` and bumps up one patch version in the package jsons for `@rive-app/react-canvas` and `@rive-app/react-webgl`
- Run `publish_all.sh` which runs the publish on both the derived react packages, also similar to wasm setup

We still keep `rive-react` around with this.
