### PR TITLE
Maint: Allow peer dep React to use v18.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@rive-app/webgl": "1.0.39"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.13.0",


### PR DESCRIPTION
Looking thru the [React changelog](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html) for supporting v18+, there should be no major changes needed here. Did some smoke tests thru some of our examples in the `examples` folder

Related to #73