### PR TITLE
Fix animation playing with autoplay false when animation name passed

### DIFF
--- a/src/hooks/useRive.tsx
+++ b/src/hooks/useRive.tsx
@@ -233,8 +233,13 @@ export default function useRive(
   const animations = riveParams?.animations;
   useEffect(() => {
     if (rive && animations) {
-      rive.stop(rive.animationNames);
-      rive.play(animations);
+      if (rive.isPlaying) {
+        rive.stop(rive.animationNames);
+        rive.play(animations);
+      } else if (rive.isPaused) {
+        rive.stop(rive.animationNames);
+        rive.pause(animations);
+      }
     }
   }, [animations, rive]);
 


### PR DESCRIPTION
Due to recent change where a change in animations names would update the playing animation. This would cause the animation to always play, even if autoplay was false. 