### PR TITLE
Fix: A recent Bunchee patch version kind of breaks npm run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",
     "auto-changelog": "^2.3.0",
-    "bunchee": "^1.7.3",
+    "bunchee": "1.8.3",
     "eslint": "^7.28.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^16.0.3",


### PR DESCRIPTION
Our `npm run build` script was failing in GH actions - after some more inspection, it looks like the `bunchee` tool we use to build released a new patch version (1.8.4) that seems to have some syntax issues that prevents building.

For now, I'm tie-ing the bunchee dep to the last working version I tested locally (one patch back)