### PR TITLE
add resizeObserver to replace window listeners for all but IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "release-it": "^14.10.0",
+    "resize-observer-polyfill": "^1.5.1",
     "ts-jest": "^27.1.1",
     "typescript": "^4.5.4",
     "watch": "^1.0.2"

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,4 +1,7 @@
 import '@testing-library/jest-dom';
+import ResizeObserver from 'resize-observer-polyfill';
+
+global.ResizeObserver = ResizeObserver;
 
 window.IntersectionObserver = class IntersectionObserver {
   readonly root: Element | null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,3 +22,35 @@ export function useWindowSize() {
   }, []);
   return windowSize;
 }
+
+// grabbed from: https://stackoverflow.com/questions/19999388/check-if-user-is-using-ie
+// There is a shorter version, but that one ran into type issues with typescript.
+export function isIE() {
+  /**
+   * detect IEEdge
+   * returns version of IE/Edge or false, if browser is not a Microsoft browser
+   */
+  const ua = window.navigator.userAgent;
+
+  const msie = ua.indexOf('MSIE ');
+  if (msie > 0) {
+    // IE 10 or older => return version number
+    return parseInt(ua.substring(msie + 5, ua.indexOf('.', msie)), 10);
+  }
+
+  const trident = ua.indexOf('Trident/');
+  if (trident > 0) {
+    // IE 11 => return version number
+    const rv = ua.indexOf('rv:');
+    return parseInt(ua.substring(rv + 3, ua.indexOf('.', rv)), 10);
+  }
+
+  const edge = ua.indexOf('Edge/');
+  if (edge > 0) {
+    // Edge => return version number
+    return parseInt(ua.substring(edge + 5, ua.indexOf('.', edge)), 10);
+  }
+
+  // other browser
+  return false;
+}

--- a/test/Rive.test.tsx
+++ b/test/Rive.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import RiveComponent from '../src/components/Rive';
-import {render} from '@testing-library/react'
+import { render } from '@testing-library/react';
 
 jest.mock('@rive-app/canvas', () => ({
   Rive: jest.fn().mockImplementation(() => ({
@@ -26,7 +26,13 @@ jest.mock('@rive-app/canvas', () => ({
 
 describe('Rive Component', () => {
   it('renders the component as a canvas and a div wrapper', () => {
-    const {container, getByLabelText} = render(<RiveComponent src="foo.riv" className="container-styles" aria-label="Foo label" />);
+    const { container, getByLabelText } = render(
+      <RiveComponent
+        src="foo.riv"
+        className="container-styles"
+        aria-label="Foo label"
+      />
+    );
     expect(container.firstChild).toHaveClass('container-styles');
     expect(getByLabelText('Foo label').tagName).toEqual('CANVAS');
   });

--- a/test/useStateMachine.test.tsx
+++ b/test/useStateMachine.test.tsx
@@ -2,7 +2,7 @@ import { mocked } from 'jest-mock';
 import { renderHook } from '@testing-library/react-hooks';
 
 import useStateMachineInput from '../src/hooks/useStateMachineInput';
-import {Rive, StateMachineInput} from '@rive-app/canvas';
+import { Rive, StateMachineInput } from '@rive-app/canvas';
 
 jest.mock('@rive-app/canvas', () => ({
   Rive: jest.fn().mockImplementation(() => ({
@@ -36,7 +36,9 @@ describe('useStateMachineInput', () => {
     const riveMock = {};
     mocked(Rive).mockImplementation(() => riveMock as Rive);
 
-    const { result } = renderHook(() => useStateMachineInput(riveMock as Rive, '', 'testInput'));
+    const { result } = renderHook(() =>
+      useStateMachineInput(riveMock as Rive, '', 'testInput')
+    );
     expect(result.current).toBeNull();
   });
 
@@ -44,7 +46,9 @@ describe('useStateMachineInput', () => {
     const riveMock = {};
     mocked(Rive).mockImplementation(() => riveMock as Rive);
 
-    const { result } = renderHook(() => useStateMachineInput(riveMock as Rive, 'smName', ''));
+    const { result } = renderHook(() =>
+      useStateMachineInput(riveMock as Rive, 'smName', '')
+    );
     expect(result.current).toBeNull();
   });
 
@@ -55,7 +59,9 @@ describe('useStateMachineInput', () => {
     };
     mocked(Rive).mockImplementation(() => riveMock as Rive);
 
-    const { result } = renderHook(() => useStateMachineInput(riveMock as Rive, 'smName', ''));
+    const { result } = renderHook(() =>
+      useStateMachineInput(riveMock as Rive, 'smName', '')
+    );
     expect(result.current).toBeNull();
   });
 
@@ -69,7 +75,9 @@ describe('useStateMachineInput', () => {
     };
     mocked(Rive).mockImplementation(() => riveMock as Rive);
 
-    const { result } = renderHook(() => useStateMachineInput(riveMock as Rive, 'smName', 'numInput'));
+    const { result } = renderHook(() =>
+      useStateMachineInput(riveMock as Rive, 'smName', 'numInput')
+    );
     expect(result.current).toBeNull();
   });
 
@@ -83,7 +91,9 @@ describe('useStateMachineInput', () => {
     };
     mocked(Rive).mockImplementation(() => riveMock as Rive);
 
-    const { result } = renderHook(() => useStateMachineInput(riveMock as Rive, 'smName', 'boolInput'));
+    const { result } = renderHook(() =>
+      useStateMachineInput(riveMock as Rive, 'smName', 'boolInput')
+    );
     expect(result.current).toBe(smInput);
   });
 
@@ -98,7 +108,9 @@ describe('useStateMachineInput', () => {
     };
     mocked(Rive).mockImplementation(() => riveMock as Rive);
 
-    const { result } = renderHook(() => useStateMachineInput(riveMock as Rive, 'smName', 'boolInput', true));
+    const { result } = renderHook(() =>
+      useStateMachineInput(riveMock as Rive, 'smName', 'boolInput', true)
+    );
     expect(result.current).toStrictEqual({
       ...smInput,
       value: true,


### PR DESCRIPTION
this should sort the sizing issue we have. tested this in our storyboard application

nice thing is that it'll trigger a few less resizes as well than the window one (as we only resize if our dom element has changed in size