### PR TITLE
update canvas dimensions to use clientWidth and Height as opposed to …

### DIFF
--- a/src/hooks/useRive.tsx
+++ b/src/hooks/useRive.tsx
@@ -104,8 +104,12 @@ export default function useRive(
    * @returns Dimensions object.
    */
   function getCanvasDimensions() {
-    const { width, height } =
-      containerRef.current?.getBoundingClientRect() ?? new DOMRect(0, 0, 0, 0);
+    // getBoundingClientRect returns the scaled width and height
+    // this will result in double scaling
+    // https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements
+
+    const width = containerRef.current?.clientWidth ?? 0;
+    const height = containerRef.current?.clientHeight ?? 0;
 
     if (rive && options.fitCanvasToArtboardHeight) {
       const { maxY, maxX } = rive.bounds;

--- a/test/useRive.test.tsx
+++ b/test/useRive.test.tsx
@@ -136,10 +136,8 @@ describe('useRive', () => {
 
     const canvasSpy = document.createElement('canvas');
     const containerSpy = document.createElement('div');
-    containerSpy.getBoundingClientRect = jest.fn().mockImplementation(() => ({
-      width: 100,
-      height: 100,
-    }));
+    jest.spyOn(containerSpy, 'clientWidth', 'get').mockReturnValue(100);
+    jest.spyOn(containerSpy, 'clientHeight', 'get').mockReturnValue(100);
 
     const { result } = renderHook(() => useRive(params));
 
@@ -176,10 +174,8 @@ describe('useRive', () => {
 
     const canvasSpy = document.createElement('canvas');
     const containerSpy = document.createElement('div');
-    containerSpy.getBoundingClientRect = jest.fn().mockImplementation(() => ({
-      width: 100,
-      height: 100,
-    }));
+    jest.spyOn(containerSpy, 'clientWidth', 'get').mockReturnValue(100);
+    jest.spyOn(containerSpy, 'clientHeight', 'get').mockReturnValue(100);
 
     const { result } = renderHook(() => useRive(params, opts));
 
@@ -216,10 +212,8 @@ describe('useRive', () => {
 
     const canvasSpy = document.createElement('canvas');
     const containerSpy = document.createElement('div');
-    containerSpy.getBoundingClientRect = jest.fn().mockImplementation(() => ({
-      width: 100,
-      height: 100,
-    }));
+    jest.spyOn(containerSpy, 'clientWidth', 'get').mockReturnValue(100);
+    jest.spyOn(containerSpy, 'clientHeight', 'get').mockReturnValue(100);
 
     const { result } = renderHook(() => useRive(params, opts));
 


### PR DESCRIPTION
…BoundingClient, to avoid getting scaled information


https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements

we're getting "double" scaling if we are in a container that is scaled, this means we get the actual size, and let the container that is scaled, scale us. 

maybe in the future we'd want to work with the scaling more aggressively.  its a shame that when we are scaled down to 50% we still have to render the full sized image. 

