### PR TITLE
Call cleanup on unmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "1.0.89",
-    "@rive-app/webgl": "1.0.85"
+    "@rive-app/canvas": "1.0.90",
+    "@rive-app/webgl": "1.0.86"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"

--- a/src/hooks/useRive.tsx
+++ b/src/hooks/useRive.tsx
@@ -215,6 +215,9 @@ export default function useRive(
           // on an unmounted component in some rare cases
           if (canvasRef.current) {
             setRive(r);
+          } else {
+            // If unmounted, cleanup the rive object immediately
+            r.cleanup();
           }
         });
       } else if (canvas === null && canvasRef.current) {
@@ -257,12 +260,13 @@ export default function useRive(
   }, [rive]);
 
   /**
-   * On unmount, stop rive from rendering.
+   * On unmount, call cleanup to cleanup any WASM generated objects that need
+   * to be manually destroyed.
    */
   useEffect(() => {
     return () => {
       if (rive) {
-        rive.stop();
+        rive.cleanup();
         setRive(null);
       }
     };

--- a/test/useRive.test.tsx
+++ b/test/useRive.test.tsx
@@ -102,16 +102,16 @@ describe('useRive', () => {
     expect(resizeToCanvasMock).toBeCalled();
   });
 
-  it('stops the rive object on unmount', async () => {
+  it('calls cleanup on the rive object on unmount', async () => {
     const params = {
       src: 'file-src',
     };
 
-    const stopMock = jest.fn();
+    const cleanupMock = jest.fn();
 
     const riveMock = {
       ...baseRiveMock,
-      stop: stopMock,
+      cleanup: cleanupMock,
     };
 
     // @ts-ignore
@@ -127,7 +127,7 @@ describe('useRive', () => {
 
     unmount();
 
-    expect(stopMock).toBeCalled();
+    expect(cleanupMock).toBeCalled();
   });
 
   it('sets the a bounds with the devicePixelRatio by default', async () => {


### PR DESCRIPTION
Also call cleanup if we detect the component unmounted after we initialise it

Depends on updating dependencies once https://github.com/rive-app/rive-wasm/pull/271 goes in