### PR TITLE
Fix: matchMedia add event listener for safari 13 and older versions

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,9 +3,9 @@ import { Dimensions } from './types';
 
 // There are polyfills for this, but they add hundreds of lines of code
 class FakeResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  observe() { }
+  unobserve() { }
+  disconnect() { }
 }
 
 function throttle(f: Function, delay: number) {
@@ -106,10 +106,14 @@ export function useDevicePixelRatio() {
     const mediaMatcher = window.matchMedia(
       `screen and (resolution: ${currentDpr}dppx)`
     );
-    mediaMatcher.addEventListener('change', updateDpr);
+    mediaMatcher.hasOwnProperty('addEventListener')
+      ? mediaMatcher.addEventListener('change', updateDpr)
+      : mediaMatcher.addListener(updateDpr);
 
     return () => {
-      mediaMatcher.removeEventListener('change', updateDpr);
+      mediaMatcher.hasOwnProperty('removeEventListener')
+        ? mediaMatcher.removeEventListener('change', updateDpr)
+        : mediaMatcher.removeListener(updateDpr);
     };
   }, [currentDpr]);
 


### PR DESCRIPTION
we found this bug in safari 13, we couldnt see any animation
that was coused by `addEventListener` in `matchMedia`
![Screenshot from 2022-12-19 11-39-56](https://user-images.githubusercontent.com/27080940/208490854-e4e0887b-1919-4e59-aab0-6b964d1795d2.png)
