### PR TITLE
patch: bump rive-wasm to allow new parameter for disabling Rive listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "1.1.3",
-    "@rive-app/webgl": "1.1.3"
+    "@rive-app/canvas": "1.1.4",
+    "@rive-app/webgl": "1.1.4"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"

--- a/src/components/Rive.tsx
+++ b/src/components/Rive.tsx
@@ -28,7 +28,11 @@ export interface RiveProps {
    * For `@rive-app/react-webgl`, sets this property to maintain a single WebGL context for multiple canvases. **We recommend to keep the default value** when rendering multiple Rive instances on a page.
    */
   useOffscreenRenderer?: boolean;
-};
+  /**
+   * Specify whether to disable Rive listeners on the canvas, thus preventing any event listeners to be attached to the canvas element
+   */
+  shouldDisableRiveListeners?: boolean;
+}
 
 const Rive = ({
   src,
@@ -37,6 +41,7 @@ const Rive = ({
   stateMachines,
   layout,
   useOffscreenRenderer = true,
+  shouldDisableRiveListeners = false,
   ...rest
 }: RiveProps & ComponentProps<'canvas'>) => {
   const params = {
@@ -46,6 +51,7 @@ const Rive = ({
     layout,
     stateMachines,
     autoplay: true,
+    shouldDisableRiveListeners,
   };
 
   const options = {


### PR DESCRIPTION
This bump enables folks to pass in `shouldDisableRiveListeners: true` when using either `useRive` or the main `<Rive />` component, which will not set any event listeners on the canvas (also tries to detect this anyways at the WASM level, but this adds the option).