### PR TITLE
chore: bump rive-wasm to 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.1.1",
-    "@rive-app/webgl": "2.1.1"
+    "@rive-app/canvas": "2.1.2",
+    "@rive-app/webgl": "2.1.2"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
Patching for a leak detected in rive-cpp