### PR TITLE
chore: bump rive-wasm to 2.1.5 for follow path fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.1.3",
-    "@rive-app/webgl": "2.1.3"
+    "@rive-app/canvas": "2.1.5",
+    "@rive-app/webgl": "2.1.5"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
Follow path constraint fix for nested artboards