### PR TITLE
chore: bump react to 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.5.0",
-    "@rive-app/webgl": "2.5.0"
+    "@rive-app/canvas": "2.7.0",
+    "@rive-app/webgl": "2.7.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
Add support for out of band assets