### PR TITLE
feat: add customDevicePixelRatio param from WASM for adjusting canvas size based on dpr

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.9.0",
-    "@rive-app/canvas-lite": "2.9.0",
-    "@rive-app/webgl": "2.9.0"
+    "@rive-app/canvas": "2.9.2",
+    "@rive-app/canvas-lite": "2.9.2",
+    "@rive-app/webgl": "2.9.2"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"

--- a/src/hooks/useDevicePixelRatio.ts
+++ b/src/hooks/useDevicePixelRatio.ts
@@ -7,10 +7,12 @@ import { useEffect, useState } from 'react';
  *
  * Source: https://github.com/rexxars/use-device-pixel-ratio/blob/main/index.ts
  *
+ * @param customDevicePixelRatio - Number to force a dpr to abide by, rather than using the window's
+ *
  * @returns dpr: Number - Device pixel ratio; ratio of physical px to resolution in CSS pixels for current device
  */
-export default function useDevicePixelRatio() {
-  const dpr = getDevicePixelRatio();
+export default function useDevicePixelRatio(customDevicePixelRatio?: number) {
+  const dpr = customDevicePixelRatio || getDevicePixelRatio();
   const [currentDpr, setCurrentDpr] = useState(dpr);
 
   useEffect(() => {
@@ -20,7 +22,7 @@ export default function useDevicePixelRatio() {
     }
 
     const updateDpr = () => {
-      const newDpr = getDevicePixelRatio();
+      const newDpr = customDevicePixelRatio || getDevicePixelRatio();
       setCurrentDpr(newDpr);
     };
     const mediaMatcher = window.matchMedia(
@@ -35,7 +37,7 @@ export default function useDevicePixelRatio() {
         ? mediaMatcher.removeEventListener('change', updateDpr)
         : mediaMatcher.removeListener(updateDpr);
     };
-  }, [currentDpr]);
+  }, [currentDpr, customDevicePixelRatio]);
 
   return currentDpr;
 }

--- a/src/hooks/useResizeCanvas.ts
+++ b/src/hooks/useResizeCanvas.ts
@@ -83,13 +83,14 @@ export default function useResizeCanvas({
     fitCanvasToArtboardHeight,
     shouldResizeCanvasToContainer,
     useDevicePixelRatio: shouldUseDevicePixelRatio,
+    customDevicePixelRatio,
   } = presetOptions;
 
   const containerSize = useContainerSize(
     containerRef,
     shouldResizeCanvasToContainer
   );
-  const currentDevicePixelRatio = useDevicePixelRatio();
+  const currentDevicePixelRatio = useDevicePixelRatio(customDevicePixelRatio);
 
   const { maxX, maxY } = artboardBounds ?? {};
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type UseRiveParameters = Partial<Omit<RiveParameters, 'canvas'>> | null;
 
 export type UseRiveOptions = {
   useDevicePixelRatio: boolean;
+  customDevicePixelRatio: number;
   fitCanvasToArtboardHeight: boolean;
   useOffscreenRenderer: boolean;
   shouldResizeCanvasToContainer: boolean;

--- a/test/useRive.test.tsx
+++ b/test/useRive.test.tsx
@@ -133,7 +133,7 @@ describe('useRive', () => {
     expect(cleanupMock).toBeCalled();
   });
 
-  it('sets the a bounds with the devicePixelRatio by default', async () => {
+  it('sets the bounds with the devicePixelRatio by default', async () => {
     const params = {
       src: 'file-src',
     };
@@ -160,6 +160,41 @@ describe('useRive', () => {
     // bounding rect
     expect(canvasSpy).toHaveAttribute('height', '200');
     expect(canvasSpy).toHaveAttribute('width', '200');
+
+    // Style height and width should be the same as returned from containers
+    // bounding rect
+    expect(canvasSpy).toHaveAttribute('style', 'width: 100px; height: 100px;');
+  });
+
+  it('sets the bounds with a specified customDevicePixelRatio if one is set', async () => {
+    const params = {
+      src: 'file-src',
+    };
+
+    global.devicePixelRatio = 2;
+
+    // @ts-ignore
+    mocked(rive.Rive).mockImplementation(() => baseRiveMock);
+
+    const canvasSpy = document.createElement('canvas');
+    const containerSpy = document.createElement('div');
+    jest.spyOn(containerSpy, 'clientWidth', 'get').mockReturnValue(100);
+    jest.spyOn(containerSpy, 'clientHeight', 'get').mockReturnValue(100);
+
+    const { result } = renderHook(() =>
+      useRive(params, { customDevicePixelRatio: 1 })
+    );
+
+    await act(async () => {
+      result.current.setCanvasRef(canvasSpy);
+      result.current.setContainerRef(containerSpy);
+      controlledRiveloadCb();
+    });
+
+    // Height and width should be 2* the width and height returned from containers
+    // bounding rect
+    expect(canvasSpy).toHaveAttribute('height', '100');
+    expect(canvasSpy).toHaveAttribute('width', '100');
 
     // Style height and width should be the same as returned from containers
     // bounding rect


### PR DESCRIPTION
WASM recently had a param addition to the `resizeDrawingSurfaceToCanvas()` API to explicitly set a number for the dpr when calculating canvas area size. Introducing that here as an option in `useRive()` 