### PR TITLE
chore: bump rive-wasm dependency to 2.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.9.2",
-    "@rive-app/canvas-lite": "2.9.2",
-    "@rive-app/webgl": "2.9.2"
+    "@rive-app/canvas": "2.10.0",
+    "@rive-app/canvas-lite": "2.10.0",
+    "@rive-app/webgl": "2.10.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
Bumps WASM for low-level specific features, and added dependencies on the WASM build. 