### PR TITLE
change hooks lifecycle to account for component reloading

### DIFF
--- a/src/hooks/useResizeCanvas.ts
+++ b/src/hooks/useResizeCanvas.ts
@@ -13,7 +13,7 @@ interface UseResizeCanvasProps {
   /**
    * Ref to the canvas element
    */
-  canvasRef: MutableRefObject<HTMLCanvasElement | null>;
+  canvasElem: HTMLCanvasElement | null;
   /**
    * Ref to the container element of the canvas
    */
@@ -55,7 +55,7 @@ interface UseResizeCanvasProps {
  */
 export default function useResizeCanvas({
   riveLoaded = false,
-  canvasRef,
+  canvasElem,
   containerRef,
   options = {},
   onCanvasHasResized,
@@ -120,7 +120,7 @@ export default function useResizeCanvas({
 
     const { width, height } = getContainerDimensions();
     let hasResized = false;
-    if (canvasRef.current) {
+    if (canvasElem) {
       // Check if the canvas parent container bounds have changed and set
       // new values accordingly
       const boundsChanged =
@@ -138,10 +138,10 @@ export default function useResizeCanvas({
         if (boundsChanged || canvasSizeChanged) {
           const newCanvasWidthProp = currentDevicePixelRatio * width;
           const newCanvasHeightProp = currentDevicePixelRatio * height;
-          canvasRef.current.width = newCanvasWidthProp;
-          canvasRef.current.height = newCanvasHeightProp;
-          canvasRef.current.style.width = width + 'px';
-          canvasRef.current.style.height = height + 'px';
+          canvasElem.width = newCanvasWidthProp;
+          canvasElem.height = newCanvasHeightProp;
+          canvasElem.style.width = width + 'px';
+          canvasElem.style.height = height + 'px';
           setLastCanvasSize({
             width: newCanvasWidthProp,
             height: newCanvasHeightProp,
@@ -149,8 +149,8 @@ export default function useResizeCanvas({
           hasResized = true;
         }
       } else if (boundsChanged) {
-        canvasRef.current.width = width;
-        canvasRef.current.height = height;
+        canvasElem.width = width;
+        canvasElem.height = height;
         setLastCanvasSize({
           width: width,
           height: height,
@@ -167,7 +167,7 @@ export default function useResizeCanvas({
     }
     isFirstSizing && setIsFirstSizing(false);
   }, [
-    canvasRef,
+    canvasElem,
     containerRef,
     containerSize,
     currentDevicePixelRatio,
@@ -184,4 +184,12 @@ export default function useResizeCanvas({
     shouldUseDevicePixelRatio,
     riveLoaded,
   ]);
+
+  // Reset width and height values when the canvas changes
+  useEffect(() => {
+    setLastCanvasSize({
+      width: 0,
+      height: 0,
+    });
+  }, [canvasElem]);
 }

--- a/test/useRive.test.tsx
+++ b/test/useRive.test.tsx
@@ -4,7 +4,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 
 import useRive from '../src/hooks/useRive';
 import * as rive from '@rive-app/canvas';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 jest.mock('@rive-app/canvas', () => ({
   Rive: jest.fn().mockImplementation(() => ({
@@ -65,8 +65,10 @@ describe('useRive', () => {
 
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
-      controlledRiveloadCb();
     });
+    await waitFor(() => {
+      controlledRiveloadCb();
+    })
     expect(result.current.rive).toBe(baseRiveMock);
     expect(result.current.canvas).toBe(canvasSpy);
   });
@@ -93,7 +95,11 @@ describe('useRive', () => {
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
       result.current.setContainerRef(containerSpy);
+    });
+    await waitFor(() => {
       controlledRiveloadCb();
+    })
+    await act(async () => {
       jest.spyOn(containerSpy, 'clientWidth', 'get').mockReturnValue(500);
       jest.spyOn(containerSpy, 'clientHeight', 'get').mockReturnValue(500);
       containerSpy.dispatchEvent(new Event('resize'));
@@ -125,8 +131,10 @@ describe('useRive', () => {
 
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
-      controlledRiveloadCb();
     });
+    await waitFor(() => {
+      controlledRiveloadCb();
+    })
 
     unmount();
 
@@ -153,6 +161,8 @@ describe('useRive', () => {
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
       result.current.setContainerRef(containerSpy);
+    });
+    await waitFor(() => {
       controlledRiveloadCb();
     });
 
@@ -188,6 +198,8 @@ describe('useRive', () => {
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
       result.current.setContainerRef(containerSpy);
+    });
+    await waitFor(() => {
       controlledRiveloadCb();
     });
 
@@ -222,6 +234,8 @@ describe('useRive', () => {
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
       result.current.setContainerRef(containerSpy);
+    });
+    await waitFor(() => {
       controlledRiveloadCb();
     });
 
@@ -260,6 +274,8 @@ describe('useRive', () => {
     await act(async () => {
       result.current.setContainerRef(containerSpy);
       result.current.setCanvasRef(canvasSpy);
+    });
+    await waitFor(() => {
       controlledRiveloadCb();
     });
 
@@ -300,6 +316,8 @@ describe('useRive', () => {
 
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
+    });
+    await waitFor(() => {
       controlledRiveloadCb();
     });
 
@@ -336,6 +354,8 @@ describe('useRive', () => {
 
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
+    });
+    await waitFor(() => {
       controlledRiveloadCb();
     });
 
@@ -379,6 +399,8 @@ describe('useRive', () => {
 
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
+    });
+    await waitFor(() => {
       controlledRiveloadCb();
     });
 
@@ -428,6 +450,8 @@ describe('useRive', () => {
 
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
+    });
+    await waitFor(() => {
       controlledRiveloadCb();
     });
 
@@ -456,6 +480,8 @@ describe('useRive', () => {
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
       result.current.setContainerRef(containerSpy);
+    });
+    await waitFor(() => {
       controlledRiveloadCb();
     });
 
@@ -463,7 +489,7 @@ describe('useRive', () => {
     expect(canvasSpy).toHaveStyle('width: 100px');
   });
 
-  it('updates the canvas dimensions and size if there is a new canvas size calculation', async () => {
+  it.only('updates the canvas dimensions and size if there is a new canvas size calculation', async () => {
     const params = {
       src: 'file-src',
     };
@@ -483,12 +509,20 @@ describe('useRive', () => {
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
       result.current.setContainerRef(containerSpy);
+    });
+    await waitFor(() => {
       controlledRiveloadCb();
-      jest.spyOn(containerSpy, 'clientWidth', 'get').mockReturnValue(200);
-      jest.spyOn(containerSpy, 'clientHeight', 'get').mockReturnValue(200);
-      containerSpy.dispatchEvent(new Event('resize'));
     });
 
+    await act(async () => {
+      jest.spyOn(containerSpy, 'clientWidth', 'get').mockReturnValue(200);
+      jest.spyOn(containerSpy, 'clientHeight', 'get').mockReturnValue(200);
+      console.log('PRE DISPATCHED');
+      containerSpy.dispatchEvent(new Event('resize'));
+      console.log('DISPATCHED');
+    });
+
+    console.log('EXPECTING');
     expect(canvasSpy).toHaveAttribute('width', '400');
     expect(canvasSpy).toHaveAttribute('height', '400');
   });
@@ -516,7 +550,13 @@ describe('useRive', () => {
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
       result.current.setContainerRef(containerSpy);
+    });
+
+    await waitFor(() => {
       controlledRiveloadCb();
+    });
+
+    await act(async () => {
       jest.spyOn(containerSpy, 'clientWidth', 'get').mockReturnValue(500);
       jest.spyOn(containerSpy, 'clientHeight', 'get').mockReturnValue(500);
       containerSpy.dispatchEvent(new Event('resize'));

--- a/test/useRive.test.tsx
+++ b/test/useRive.test.tsx
@@ -67,8 +67,11 @@ describe('useRive', () => {
       result.current.setCanvasRef(canvasSpy);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
-    })
+    });
     expect(result.current.rive).toBe(baseRiveMock);
     expect(result.current.canvas).toBe(canvasSpy);
   });
@@ -97,8 +100,11 @@ describe('useRive', () => {
       result.current.setContainerRef(containerSpy);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
-    })
+    });
     await act(async () => {
       jest.spyOn(containerSpy, 'clientWidth', 'get').mockReturnValue(500);
       jest.spyOn(containerSpy, 'clientHeight', 'get').mockReturnValue(500);
@@ -133,8 +139,11 @@ describe('useRive', () => {
       result.current.setCanvasRef(canvasSpy);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
-    })
+    });
 
     unmount();
 
@@ -163,6 +172,9 @@ describe('useRive', () => {
       result.current.setContainerRef(containerSpy);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
     });
 
@@ -200,6 +212,9 @@ describe('useRive', () => {
       result.current.setContainerRef(containerSpy);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
     });
 
@@ -236,6 +251,9 @@ describe('useRive', () => {
       result.current.setContainerRef(containerSpy);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
     });
 
@@ -276,6 +294,9 @@ describe('useRive', () => {
       result.current.setCanvasRef(canvasSpy);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
     });
 
@@ -297,6 +318,7 @@ describe('useRive', () => {
     const restore = global.IntersectionObserver;
     global.IntersectionObserver = jest.fn().mockImplementation(() => ({
       observe: observeMock,
+      disconnect: ()=>{}
     }));
 
     const riveMock = {
@@ -318,7 +340,13 @@ describe('useRive', () => {
       result.current.setCanvasRef(canvasSpy);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
+    });
+    await waitFor(() => {
+      expect(result.current.rive).toBe(riveMock);
     });
 
     expect(observeMock).toBeCalledWith(canvasSpy);
@@ -356,6 +384,9 @@ describe('useRive', () => {
       result.current.setCanvasRef(canvasSpy);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
     });
 
@@ -401,6 +432,9 @@ describe('useRive', () => {
       result.current.setCanvasRef(canvasSpy);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
     });
 
@@ -427,6 +461,11 @@ describe('useRive', () => {
 
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
+    });
+    await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
     });
 
@@ -452,6 +491,9 @@ describe('useRive', () => {
       result.current.setCanvasRef(canvasSpy);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
     });
 
@@ -482,6 +524,9 @@ describe('useRive', () => {
       result.current.setContainerRef(containerSpy);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
     });
 
@@ -513,6 +558,9 @@ describe('useRive', () => {
       jest.spyOn(containerSpy, 'clientHeight', 'get').mockReturnValue(200);
     });
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
     });
 
@@ -550,6 +598,9 @@ describe('useRive', () => {
     });
 
     await waitFor(() => {
+      expect(result.current.canvas).toBe(canvasSpy);
+    });
+    await act(async () => {
       controlledRiveloadCb();
     });
 

--- a/test/useRive.test.tsx
+++ b/test/useRive.test.tsx
@@ -489,7 +489,7 @@ describe('useRive', () => {
     expect(canvasSpy).toHaveStyle('width: 100px');
   });
 
-  it.only('updates the canvas dimensions and size if there is a new canvas size calculation', async () => {
+  it('updates the canvas dimensions and size if there is a new canvas size calculation', async () => {
     const params = {
       src: 'file-src',
     };
@@ -509,20 +509,17 @@ describe('useRive', () => {
     await act(async () => {
       result.current.setCanvasRef(canvasSpy);
       result.current.setContainerRef(containerSpy);
+      jest.spyOn(containerSpy, 'clientWidth', 'get').mockReturnValue(200);
+      jest.spyOn(containerSpy, 'clientHeight', 'get').mockReturnValue(200);
     });
     await waitFor(() => {
       controlledRiveloadCb();
     });
 
     await act(async () => {
-      jest.spyOn(containerSpy, 'clientWidth', 'get').mockReturnValue(200);
-      jest.spyOn(containerSpy, 'clientHeight', 'get').mockReturnValue(200);
-      console.log('PRE DISPATCHED');
       containerSpy.dispatchEvent(new Event('resize'));
-      console.log('DISPATCHED');
     });
 
-    console.log('EXPECTING');
     expect(canvasSpy).toHaveAttribute('width', '400');
     expect(canvasSpy).toHaveAttribute('height', '400');
   });


### PR DESCRIPTION
fixes #255 
this PR changes some parts of our hooks lifecycle to reload an animation if it has been previously destroyed.