### PR TITLE
Fix: await file init in useRiveFile to catch async errors

### DIFF
--- a/src/hooks/useRiveFile.ts
+++ b/src/hooks/useRiveFile.ts
@@ -26,7 +26,6 @@ function useRiveFile(params: UseRiveFileParameters): RiveFileState {
       try {
         setStatus('loading');
         file = new RiveFile(params);
-        await file.init();
         file.on(EventType.Load, () => {
           // We request an instance to add +1 to the referencesCount so it doesn't get destroyed
           // while this hook is active
@@ -37,6 +36,7 @@ function useRiveFile(params: UseRiveFileParameters): RiveFileState {
         file.on(EventType.LoadError, () => {
           setStatus('failed');
         });
+        await file.init();
         setRiveFile(file);
       } catch (error) {
         console.error(error);

--- a/src/hooks/useRiveFile.ts
+++ b/src/hooks/useRiveFile.ts
@@ -26,7 +26,7 @@ function useRiveFile(params: UseRiveFileParameters): RiveFileState {
       try {
         setStatus('loading');
         file = new RiveFile(params);
-        file.init();
+        await file.init();
         file.on(EventType.Load, () => {
           // We request an instance to add +1 to the referencesCount so it doesn't get destroyed
           // while this hook is active


### PR DESCRIPTION
@damzobridge @bodymovin 

When testing out https://github.com/rive-app/rive-react/pull/269, I realized that the errors thrown by `file.init()` were not actually being caught by the try/catch due to `init` being async. 

In the `rive-wasm` repo, in order to catch the errors thrown within the async init of the file, they use `await` (https://github.com/rive-app/rive-wasm/blob/6d5cd8909a635184f156be03d1f32d5ceb4025fc/js/src/rive.ts#L1739).

Testing locally, this fixes my issue!

Before:
The app still crashes if I pass a bad `src` to `useRiveFile`.

After:
If there's a bad `src`, the app does not crash anymore. If the `src` is valid, the Rive file loads and the animation plays as expected.