### PR TITLE
fix: change initialization from play to load event

### DIFF
--- a/src/hooks/useStateMachineInput.ts
+++ b/src/hooks/useStateMachineInput.ts
@@ -40,7 +40,7 @@ export default function useStateMachineInput(
     }
     setStateMachineInput();
     if (rive) {
-      rive.on(EventType.Play, () => {
+      rive.on(EventType.Load, () => {
         // Check if the component/canvas is mounted before setting state to avoid setState
         // on an unmounted component in some rare cases
         setStateMachineInput();


### PR DESCRIPTION
This PR addresses the issue where state machine inputs reset when `rive.play()` is called.