### PR TITLE
fix: add webgl2 package to dependencies

### DIFF
--- a/npm/react-webgl2/package.json
+++ b/npm/react-webgl2/package.json
@@ -17,7 +17,9 @@
     "url": "https://github.com/rive-app/rive-react/issues"
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
-  "dependencies": {},
+  "dependencies": {
+    "@rive-app/webgl2": "2.19.4"
+  },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "@rive-app/canvas": "2.19.4",
     "@rive-app/canvas-lite": "2.19.4",
-    "@rive-app/webgl": "2.19.4"
+    "@rive-app/webgl": "2.19.4",
+    "@rive-app/webgl2": "2.19.4"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
This PR addresses the issue with the `@rive-app/react-webgl2` package where imports from the underlying `@rive-app/webgl2` package are missing. 

For example, using this import statement: `import {decodeFont} from '@rive-app/react-webgl2';` would result in this error: `Module '"@rive-app/react-webgl2"' has no exported member 'decodeFont'.`