### PR TITLE
fix: additional layout configuration that react needs

### DIFF
--- a/src/hooks/useRive.tsx
+++ b/src/hooks/useRive.tsx
@@ -83,7 +83,7 @@ export default function useRive(
    */
   const onCanvasHasResized = useCallback(() => {
     if (rive) {
-      if (rive.layout.fit === Fit.Layout) {
+      if (rive.layout && rive.layout.fit === Fit.Layout) {
         if (canvasElem) {
           // TODO (Gordon): expose these are properties on JS runtime
           (rive as any)._devicePixelRatioUsed = devicePixelRatio;


### PR DESCRIPTION
React ended up needing a few extra things. I thought it used `resizeDrawingSurfaceToCanvas` and not `resizeToCanvas`.

This can be cleaned up more as we need some properties from JS. Later we would also need to test a few more scenarios to make sure this always works as intended.