### PR TITLE
Fix: Prevent scrollbars from flashing on resize

### DIFF
--- a/src/hooks/useRive.tsx
+++ b/src/hooks/useRive.tsx
@@ -29,6 +29,7 @@ function RiveComponent({
   const containerStyle = {
     width: '100%',
     height: '100%',
+    overflow: 'hidden',
     ...style,
   };
 

--- a/test/useRive.test.tsx
+++ b/test/useRive.test.tsx
@@ -428,6 +428,7 @@ describe('useRive', () => {
       <RiveTestComponent className="rive-test-clas" style={{ width: '50%' }} />
     );
     expect(container.firstChild).not.toHaveStyle('width: 50%');
+    expect(container.firstChild).not.toHaveStyle('overflow: hidden');
   });
 
   it('has a canvas size of 0 by default', async () => {
@@ -454,6 +455,7 @@ describe('useRive', () => {
     const { RiveComponent: RiveTestComponent } = result.current;
     const { container } = render(<RiveTestComponent />);
     expect(container.querySelector('canvas')).toHaveStyle('width: 0');
+    expect(container.firstChild).toHaveStyle('overflow: hidden');
   });
 
   it('sets the canvas width and height after calculating the container size', async () => {


### PR DESCRIPTION
# The Problem

When the Rive component is full width/height and you resize the page, you sometimes see the scrollbars flash on/off. When you zoom in on your browser, sometimes it gets stuck in a loop the scrollbars flashing on/off. 

![CleanShot 2024-11-15 at 09 50 09](https://github.com/user-attachments/assets/95a1580b-65cf-4a33-9d42-84c87907e1db)
![CleanShot 2024-11-15 at 09 50 37](https://github.com/user-attachments/assets/8b05b91b-21dc-4e53-a880-001d461382fb)

# Why is this happening?

`rive-react` listens for a window resize then updates the canvas CSS width/height. There's an instant when the page has a new width, but the CSS hasn't updated yet. 

When you zoom in to a certain level, it looks like it triggers another resize every time the scrollbars appear or disappear. 

# The fix

Add `overflow: hidden` to the container `div` that holds the `canvas` element. 

![CleanShot 2024-11-14 at 21 26 32](https://github.com/user-attachments/assets/d355be6f-46a7-4a7b-bd79-8558d39bbe8f)
![CleanShot 2024-11-14 at 21 27 13](https://github.com/user-attachments/assets/261db907-ef1c-4cd4-8867-1de54a1f326f)

# Testing

There are 2 new tests: 

- Make sure the container includes the `overflow: hidden` CSS style
- If the user includes a `className` in the `<RiveComponent>`, make sure we don't include the new CSS style

Run `npm test`

Other things to test: 

- Check out each of the existing examples to make sure nothing changed
- Scale a fullscreen rive element to make sure you don't see scrollbars
- Cmd +/- a fullscreen rive element to make sure you don't see scrollbars

