### PR TITLE
cleanup instance if use effect reruns and instance is not loaded

### DIFF
--- a/src/hooks/useRive.tsx
+++ b/src/hooks/useRive.tsx
@@ -126,23 +126,31 @@ export default function useRive(
     if (!canvasElem || !riveParams) {
       return;
     }
+    let isLoaded = rive != null;
+    let r: Rive | null;
     if (rive == null) {
       const { useOffscreenRenderer } = options;
-      const r = new Rive({
+      r = new Rive({
         useOffscreenRenderer,
         ...riveParams,
         canvas: canvasElem,
       });
       r.on(EventType.Load, () => {
+        isLoaded = true;
         // Check if the component/canvas is mounted before setting state to avoid setState
         // on an unmounted component in some rare cases
         if (canvasElem) {
           setRive(r);
         } else {
           // If unmounted, cleanup the rive object immediately
-          r.cleanup();
+          r!.cleanup();
         }
       });
+    }
+    return () => {
+      if(!isLoaded) {
+        r?.cleanup();
+      }
     }
   }, [canvasElem, isParamsLoaded, rive]);
   /**


### PR DESCRIPTION
in a scenario where the instance was not loaded yet and the useEffect would run again, we were not cleaning up the instance causing memory leaks because elements were not being deleted. 