### PR TITLE
feat: add onRiveReady callback to useRive hook

### DIFF
--- a/src/hooks/useRive.tsx
+++ b/src/hooks/useRive.tsx
@@ -131,9 +131,10 @@ export default function useRive(
     let r: Rive | null;
     if (rive == null) {
       const { useOffscreenRenderer } = options;
+      const { onRiveReady, ...restRiveParams } = riveParams;
       r = new Rive({
         useOffscreenRenderer,
-        ...riveParams,
+        ...restRiveParams,
         canvas: canvasElem,
       });
       if (riveRef.current != null) {
@@ -143,8 +144,8 @@ export default function useRive(
       r.on(EventType.Load, () => {
         isLoaded = true;
 
-        if (options.onLoad) {
-          options.onLoad(r!);
+        if (onRiveReady) {
+          onRiveReady(r!);
         }
 
         // Check if the component/canvas is mounted before setting state to avoid setState

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,9 @@ import {
 } from '@rive-app/canvas';
 import { ComponentProps, RefCallback } from 'react';
 
-export type UseRiveParameters = Partial<Omit<RiveParameters, 'canvas'>> | null;
+export type UseRiveParameters = Partial<Omit<RiveParameters, 'canvas'>> & {
+  onRiveReady?: (rive: Rive) => void;
+} | null;
 
 export type UseRiveOptions = {
   useDevicePixelRatio: boolean;
@@ -15,7 +17,6 @@ export type UseRiveOptions = {
   useOffscreenRenderer: boolean;
   shouldResizeCanvasToContainer: boolean;
   shouldUseIntersectionObserver?: boolean;
-  onLoad?: (rive: Rive) => void;
 };
 
 export type Dimensions = {


### PR DESCRIPTION
This PR adds an `onRiveReady` callback to the `useRive` hook. There's already an `onLoad` callback in the hook's `UseRiveParameters`, however, it doesn't include the rive object, so users can't set inputs or do anything within that callback.

So this adds a version of the callback that includes the Rive object.

```
const { rive, RiveComponent } = useRive({
    src: 'rating.riv',
    stateMachines: 'State Machine 1',
    autoplay: true,
    automaticallyHandleEvents: true,
    onRiveReady: (rive) => {
      console.log('Rive loaded', rive);
      const inputs = rive.stateMachineInputs('State Machine 1');
      inputs.forEach(i => {

        if (i.name === "rating") {
          i.value = 3;
          return;
        }
      });
    }
  });
  ```
  
This lets users set initial values on the rive file before the first render, which is important for some rive graphics that expect values to show up immediately.