### PR TITLE
chore: auto publish false for release-it

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -7,7 +7,7 @@
     "changelog": "npx auto-changelog --stdout --commit-limit false --unreleased --template https://raw.githubusercontent.com/release-it/release-it/master/templates/changelog-compact.hbs"
   },
   "npm": {
-    "publish": true
+    "publish": false
   },
   "github": {
     "release": true,


### PR DESCRIPTION
This is an attempt at resolving failed publishing with OIDC.

With `publish: false`, release-it won't automatically publish or check npm authentication. The current assumption is that this is causing a pre-authentication check to fail. Publishing will happen via `npm run publish:all` in the hooks, and npm will automatically use OIDC when it runs.

This is _similar_ to what rive-wasm does with its action.