### PR TITLE
chore: bump rive js/wasm to 2.35.4 for underlying mesh fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.35.3",
-    "@rive-app/canvas-lite": "2.35.3",
-    "@rive-app/webgl": "2.35.3",
-    "@rive-app/webgl2": "2.35.3"
+    "@rive-app/canvas": "2.35.4",
+    "@rive-app/canvas-lite": "2.35.4",
+    "@rive-app/webgl": "2.35.4",
+    "@rive-app/webgl2": "2.35.4"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0"


### PR DESCRIPTION
- Fix underlying mesh crash on canvas2d rendering when left running for long periods of time
- Expose new `DataType` named import for Property value data types (i.e. `DataType.string`)