### PR TITLE
chore: bump js runtime to 2.37.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "4.28.0",
       "license": "MIT",
       "dependencies": {
-        "@rive-app/canvas": "2.37.1",
-        "@rive-app/canvas-lite": "2.37.1",
-        "@rive-app/webgl2": "2.37.1"
+        "@rive-app/canvas": "2.37.2",
+        "@rive-app/canvas-lite": "2.37.2",
+        "@rive-app/webgl2": "2.37.2"
       },
       "devDependencies": {
         "@babel/core": "^7.18.0",
@@ -1357,21 +1357,21 @@
       }
     },
     "node_modules/@rive-app/canvas": {
-      "version": "2.37.1",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.37.1.tgz",
-      "integrity": "sha512-Uw14b9vXD5g56ttUktlV+mXX1EOpAwqOoMS+DAVSs6EDoeaUYM4bRSKB1glDiOotqjshLSfNihua73mLPp10cQ==",
+      "version": "2.37.2",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.37.2.tgz",
+      "integrity": "sha512-AWdyanRg1hZ0XLr/KQu4/F9FtPNX2LBhyOGq29WRdVNa8KfQHxJ+LJQY/hEkCbbEtTkv50PYSwWjTFHhFSAZAg==",
       "license": "MIT"
     },
     "node_modules/@rive-app/canvas-lite": {
-      "version": "2.37.1",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.37.1.tgz",
-      "integrity": "sha512-2ZiV4Sq3l0o5b52SmtzGrxNTvL+klX258eiw+0r4mum60EiUbtSpOTnMrOneM5V3TxpcXk+su+bNIkUcEzd0+Q==",
+      "version": "2.37.2",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.37.2.tgz",
+      "integrity": "sha512-Pp8R/ZpZliwkPm684HFIKZ4N6UurcfbfFQXV74+HV2bxAutpQYsDCr0sOjEgJC/brG5aeSCVyJY3Iq7nNAkmeQ==",
       "license": "MIT"
     },
     "node_modules/@rive-app/webgl2": {
-      "version": "2.37.1",
-      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.37.1.tgz",
-      "integrity": "sha512-ll7HBYQfhxKUPYspJpICajIrPfPyg63rj3obqulRjwrzlmwXljoOl8CQgUofZi/pNM1Cfz3Und+nB8irK8tuQg==",
+      "version": "2.37.2",
+      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.37.2.tgz",
+      "integrity": "sha512-fQFBGDcjOGNIyhW33lBdamj15oVJTCLHsKBKGolXFjHziFj+Fw0kKd3pRekZNkyfZ0IUQwoS/P2bnF+Vz98CrQ==",
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.37.1",
-    "@rive-app/canvas-lite": "2.37.1",
-    "@rive-app/webgl2": "2.37.1"
+    "@rive-app/canvas": "2.37.2",
+    "@rive-app/canvas-lite": "2.37.2",
+    "@rive-app/webgl2": "2.37.2"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0"


### PR DESCRIPTION
- Fixes pixel local storage extension usage
- Exposes `setWasmBinary` option via `RuntimeLoader` export to set WASM bytes
- Exposes `setWasmFallbackUrl` option via `RuntimeLoader` export to set fallback URL to fetch WASM