### PR TITLE
chore: bump js runtime to 2.37.6 to get error handling improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "4.28.3",
       "license": "MIT",
       "dependencies": {
-        "@rive-app/canvas": "2.37.5",
-        "@rive-app/canvas-lite": "2.37.5",
-        "@rive-app/webgl2": "2.37.5"
+        "@rive-app/canvas": "2.37.6",
+        "@rive-app/canvas-lite": "2.37.6",
+        "@rive-app/webgl2": "2.37.6"
       },
       "devDependencies": {
         "@babel/core": "^7.18.0",
@@ -1357,21 +1357,21 @@
       }
     },
     "node_modules/@rive-app/canvas": {
-      "version": "2.37.5",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.37.5.tgz",
-      "integrity": "sha512-o0oCrdyxDLTahj60dXxUiB6I/xyi7hKaUJX+hce0jL0qcV1YtI+f+KGb/6EAMMBZMjT1if7OJFzT/6zA2YiNGA==",
+      "version": "2.37.6",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.37.6.tgz",
+      "integrity": "sha512-TxovQ8p1aJJ1PzClRX4Dxhp0As4P8slZWG+FJq40/kXXQDqit5ndj7thW5LlbsvKRyA7HYZQUqL97wAH+emIFA==",
       "license": "MIT"
     },
     "node_modules/@rive-app/canvas-lite": {
-      "version": "2.37.5",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.37.5.tgz",
-      "integrity": "sha512-IyJIm2cL2PlbTqQrgawoR2+k5rA4wP52IxAk7fksXGirKBURLvaUmCtTRqGCx4KfKzpK4z6O8M/LD/j7CQsT4Q==",
+      "version": "2.37.6",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.37.6.tgz",
+      "integrity": "sha512-ZCHaNCi9szHGqrZPiNXBKGPKu7/frMTjR6LAAabHr2681rKjZyZ0xUsPoWwpz9zL1bTckDYWLRMF0FORqVD/5A==",
       "license": "MIT"
     },
     "node_modules/@rive-app/webgl2": {
-      "version": "2.37.5",
-      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.37.5.tgz",
-      "integrity": "sha512-HvzjvComnOh1pns/BIGbnrZglNxNov5yhmpWO2+i6jlrbV8uovgAWlNm4HTmt+X6eKDrnh8x6G236ABXIqoORQ==",
+      "version": "2.37.6",
+      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.37.6.tgz",
+      "integrity": "sha512-ZvUgD8yleilzqu0DuQF2r9bFOk+id1cmgSE/4QayyNGlqUTgANcKs2Ft78F27qeGLO06SE589ugrdgZLtL4kbw==",
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.37.5",
-    "@rive-app/canvas-lite": "2.37.5",
-    "@rive-app/webgl2": "2.37.5"
+    "@rive-app/canvas": "2.37.6",
+    "@rive-app/canvas-lite": "2.37.6",
+    "@rive-app/webgl2": "2.37.6"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0"


### PR DESCRIPTION
- Error handling improvements to accurately invoke `onLoadError()`
- Rendering improvements re: WebGL2 and blend modes
- Other various internal feature improvements