### PR TITLE
chore: bump js runtimes to 2.37.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "4.28.5",
       "license": "MIT",
       "dependencies": {
-        "@rive-app/canvas": "2.37.7",
-        "@rive-app/canvas-lite": "2.37.7",
-        "@rive-app/webgl2": "2.37.7"
+        "@rive-app/canvas": "2.37.8",
+        "@rive-app/canvas-lite": "2.37.8",
+        "@rive-app/webgl2": "2.37.8"
       },
       "devDependencies": {
         "@babel/core": "^7.18.0",
@@ -1357,21 +1357,21 @@
       }
     },
     "node_modules/@rive-app/canvas": {
-      "version": "2.37.7",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.37.7.tgz",
-      "integrity": "sha512-dS2W4igbETc3zxWhDO8x8wyB8HrtZCG48ofODBijHbV5lINYTz8Xx3P1mHtK/ywzKWhaSSAI95QTz9FqJG1ghQ==",
+      "version": "2.37.8",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.37.8.tgz",
+      "integrity": "sha512-nffrPG+VkBKHAxZdcqYlP5M+n/mOAoagj774HH397UPTsfC27gwQURg64i6dX7WswMc5qIVX0rzCrZ86Wb2HOA==",
       "license": "MIT"
     },
     "node_modules/@rive-app/canvas-lite": {
-      "version": "2.37.7",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.37.7.tgz",
-      "integrity": "sha512-PPxFyPZ85NfB260tDqynU2yajlZRvujc1qFR7GB3b+7etnmumTPtCmYyjkkj2m0ZXVjPpuf97TkqSsZ4sgXb3w==",
+      "version": "2.37.8",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.37.8.tgz",
+      "integrity": "sha512-VGhz94ugNKw38OdMMF4Q/O0rM3vnyAQxfe/VLqNlZ2cteSh/lpQ4NKJeeBFa2jdknu6vUFVv1pWkHKoCdQ9f0Q==",
       "license": "MIT"
     },
     "node_modules/@rive-app/webgl2": {
-      "version": "2.37.7",
-      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.37.7.tgz",
-      "integrity": "sha512-UBhiWn9Ujjsl7H98pv5WKvUvhh79xd2IkFhT6BvK0Z3rFC6ikqDZ9odUokwhmQa8xoaJT3rDL9t5aq4wlqBrsQ==",
+      "version": "2.37.8",
+      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.37.8.tgz",
+      "integrity": "sha512-Y2nXPwAeQtZrADNIzY7v3Lk7XZRMy4Gd+bpGFyzkaQ/EQ91Hp/6sCdd8yTCyjH4b71N/T6kU0MHIYA0IDmpjyQ==",
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.37.7",
-    "@rive-app/canvas-lite": "2.37.7",
-    "@rive-app/webgl2": "2.37.7"
+    "@rive-app/canvas": "2.37.8",
+    "@rive-app/canvas-lite": "2.37.8",
+    "@rive-app/webgl2": "2.37.8"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0"


### PR DESCRIPTION
- Fixes state machine sync issue when tab is switched or window is minimized
- Supports focus management (user-driven) on `.riv` files that have focus nodes