### PR TITLE
chore: bump rive-wasm to 2.38.0 for focus management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "4.28.6",
       "license": "MIT",
       "dependencies": {
-        "@rive-app/canvas": "2.37.8",
-        "@rive-app/canvas-lite": "2.37.8",
-        "@rive-app/webgl2": "2.37.8"
+        "@rive-app/canvas": "2.38.0",
+        "@rive-app/canvas-lite": "2.38.0",
+        "@rive-app/webgl2": "2.38.0"
       },
       "devDependencies": {
         "@babel/core": "^7.18.0",
@@ -1357,21 +1357,21 @@
       }
     },
     "node_modules/@rive-app/canvas": {
-      "version": "2.37.8",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.37.8.tgz",
-      "integrity": "sha512-nffrPG+VkBKHAxZdcqYlP5M+n/mOAoagj774HH397UPTsfC27gwQURg64i6dX7WswMc5qIVX0rzCrZ86Wb2HOA==",
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.38.0.tgz",
+      "integrity": "sha512-tTrPXsWJZLARBa3H9rOPVMrWp5IRwaVABHLISdBogGGebp0sIAAmfDAD1eK/bP+UODejsT4X3mPBI3GPNln44g==",
       "license": "MIT"
     },
     "node_modules/@rive-app/canvas-lite": {
-      "version": "2.37.8",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.37.8.tgz",
-      "integrity": "sha512-VGhz94ugNKw38OdMMF4Q/O0rM3vnyAQxfe/VLqNlZ2cteSh/lpQ4NKJeeBFa2jdknu6vUFVv1pWkHKoCdQ9f0Q==",
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.38.0.tgz",
+      "integrity": "sha512-iNsbPGGoK8cy9VAWjklxxU53C5RXIOS38cqnR94gzJKYwYQ3hZ9KWQ8nmnRJ8Tla+9MDM902e9rEjATMBssAkQ==",
       "license": "MIT"
     },
     "node_modules/@rive-app/webgl2": {
-      "version": "2.37.8",
-      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.37.8.tgz",
-      "integrity": "sha512-Y2nXPwAeQtZrADNIzY7v3Lk7XZRMy4Gd+bpGFyzkaQ/EQ91Hp/6sCdd8yTCyjH4b71N/T6kU0MHIYA0IDmpjyQ==",
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.38.0.tgz",
+      "integrity": "sha512-icwQjMP7cJccK37lgGG4L1XagSeMObKylFTTd6Ob4nAEvCajSGZvQV2pE/tcXYd17eR9laIM3lI0y8zbI1eiiw==",
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.37.8",
-    "@rive-app/canvas-lite": "2.37.8",
-    "@rive-app/webgl2": "2.37.8"
+    "@rive-app/canvas": "2.38.0",
+    "@rive-app/canvas-lite": "2.38.0",
+    "@rive-app/webgl2": "2.38.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0"


### PR DESCRIPTION
- fix: advance state machine by 0 after pointerUp/Down to process events/vm prop value change callbacks
- feat: pt 2 focus management - poll focus state each frame and drive focus to canvas if needed
- fix: prevent calling assetLoader callback for non-actionable asset types at runtime