### PR TITLE
chore: bump rive-wasm to 2.38.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "4.29.1",
       "license": "MIT",
       "dependencies": {
-        "@rive-app/canvas": "2.38.1",
-        "@rive-app/canvas-lite": "2.38.1",
-        "@rive-app/webgl2": "2.38.1"
+        "@rive-app/canvas": "2.38.2",
+        "@rive-app/canvas-lite": "2.38.2",
+        "@rive-app/webgl2": "2.38.2"
       },
       "devDependencies": {
         "@babel/core": "^7.18.0",
@@ -1357,21 +1357,21 @@
       }
     },
     "node_modules/@rive-app/canvas": {
-      "version": "2.38.1",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.38.1.tgz",
-      "integrity": "sha512-iK5HH2N1ZtkgbGV9nkIEyTv6j7Zbx6tVns/y6a8Yk+hPPnQl8XO5RS6gMM4V2NNmyvQ9PnAmnZDNaZCJUtaU8g==",
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.38.2.tgz",
+      "integrity": "sha512-UQgKz/1PFbMWNZ5IDWct8AkUkXaDhmHFFD9yXJ5GyldhwGYFXmfDcKQtUozYTHqqMOD6b9mRHTYUTkPc2etcdQ==",
       "license": "MIT"
     },
     "node_modules/@rive-app/canvas-lite": {
-      "version": "2.38.1",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.38.1.tgz",
-      "integrity": "sha512-8MZrDcDNlyDr9KQN3XajPokC+C6BvH3vav73Q+sUozEYK6jgQjERsGmabvjH53ayYMiLtzMni/5Til91pCmFDQ==",
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.38.2.tgz",
+      "integrity": "sha512-nrzmwHbSZ3ffvcz+zytXBriSpEUTfOq7qYMurAflgVMre4NBFQbJ2BkpJ5auxLNBFvSWxLBDyDv2BAQsEKzsDQ==",
       "license": "MIT"
     },
     "node_modules/@rive-app/webgl2": {
-      "version": "2.38.1",
-      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.38.1.tgz",
-      "integrity": "sha512-dotNsRlrTaHNxTiJFxHHycB1PQhnJyIvrMTVpyzG6GYgjztnM27r07e8GJ2AuDQB/Vkmdz0Y6NRG5NVJ1OWDxQ==",
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.38.2.tgz",
+      "integrity": "sha512-pmhAlE6Qxo3rrJEbTwXDFffpRIDNWMtBcxYjANIo6Vii2I5Z4exciQGQCg9YOsXPVHoM3fFU9KK23UmiCWMeUw==",
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.38.1",
-    "@rive-app/canvas-lite": "2.38.1",
-    "@rive-app/webgl2": "2.38.1"
+    "@rive-app/canvas": "2.38.2",
+    "@rive-app/canvas-lite": "2.38.2",
+    "@rive-app/webgl2": "2.38.2"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0"


### PR DESCRIPTION
- fix(js): Re-bind GL context before artboard/file teardown and for offscreen renderers
- fix(js): Add asset Wrapper types to type definition on asset setter APIs to fix TS mismatch error