### PR TITLE
fix: fix github release command to resume releases and match the format of other runtimes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ on:
 
 permissions:
   id-token: write # Required for OIDC
-  contents: read
+  contents: write
 
 jobs:
   publish_job:
@@ -44,9 +44,15 @@ jobs:
       - if: ${{ inputs.major == true }}
         name: Major Release - Bump version number, update changelog, push and tag
         run: npm run release:major
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: ${{inputs.major == false && inputs.minor == true}}
         name: Minor release - Bump version number, update changelog, push and tag
         run: npm run release:minor
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: ${{inputs.major == false && inputs.minor == false}}
         name: Patch release - Bump version number, update changelog, push and tag
         run: npm run release:patch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   id-token: write # Required for OIDC
   contents: write
+  issues: write
 
 jobs:
   publish_job:
@@ -56,3 +57,41 @@ jobs:
         run: npm run release:patch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify packages are available on npm
+        run: |
+          for i in $(seq 1 10); do
+            missing=0
+            for pkg_json in npm/*/package.json; do
+              PKG=$(node -p "require('./${pkg_json}').name")
+              VERSION=$(node -p "require('./${pkg_json}').version")
+              if npm view "$PKG@$VERSION" version > /dev/null 2>&1; then
+                echo "$PKG@$VERSION is live on npm"
+              else
+                echo "$PKG@$VERSION not visible on npm yet"
+                missing=1
+              fi
+            done
+            if [ "$missing" -eq 0 ]; then
+              echo "All packages are live on npm"
+              exit 0
+            fi
+            echo "Retrying in 30s ($i/10)"
+            sleep 30
+          done
+          echo "One or more packages did not appear on npm"
+          exit 1
+
+      - name: File issue on publish failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          gh issue create --repo "$GITHUB_REPOSITORY" \
+            --title "Publish workflow failed for v${VERSION}" \
+            --body "The publish workflow for \`v${VERSION}\` failed; check if the packages are fully available on npm.
+
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          cc @zplata"

--- a/.release-it.json
+++ b/.release-it.json
@@ -11,7 +11,8 @@
   },
   "github": {
     "release": true,
-    "releaseName": "${version}"
+    "releaseName": "${version}",
+    "releaseNotes": "npx auto-changelog --stdout --commit-limit false --unreleased --template https://raw.githubusercontent.com/release-it/release-it/master/templates/changelog-compact.hbs"
   },
   "hooks": {
     "after:version:bump": [


### PR DESCRIPTION
Github releases stopped automatically publishing due to needing the `GITHUB_TOKEN`. Adding that back in and aligning the release notes to other runtime formats.

Also adding what we added for the JS runtime, where Rive team gets notified of a npm publish failure via a new GH issue.