### PR TITLE
chore: bump JS runtime to 2.39.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "4.30.0",
       "license": "MIT",
       "dependencies": {
-        "@rive-app/canvas": "2.39.1",
-        "@rive-app/canvas-lite": "2.39.1",
-        "@rive-app/webgl2": "2.39.1"
+        "@rive-app/canvas": "2.39.2",
+        "@rive-app/canvas-lite": "2.39.2",
+        "@rive-app/webgl2": "2.39.2"
       },
       "devDependencies": {
         "@babel/core": "^7.18.0",
@@ -1357,21 +1357,21 @@
       }
     },
     "node_modules/@rive-app/canvas": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.39.1.tgz",
-      "integrity": "sha512-7Q2LNtFO4GaI78DZaH2aL6nI3EKFT5PIwj1XtFWzXYd6wUvCpc3fyk0WRzgX65DFMTdmbHl8EWVm+UEtzd8xXQ==",
+      "version": "2.39.2",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.39.2.tgz",
+      "integrity": "sha512-qC/Wc6gokYwxOD1TXX4hK9AKevLACQC04Xy0pkOseru45SzWxhqIUEWZLzM4LX5B5MQmWAbWhCVmTOTvYFTzHA==",
       "license": "MIT"
     },
     "node_modules/@rive-app/canvas-lite": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.39.1.tgz",
-      "integrity": "sha512-0TNYD2QKF9S0k9+eB1LtArTCrzXPdecEQnrjdg2EXGuF7sDVcpUDP5cU4Hjf6ZqcsA+y05pWe9srhl0tUFsSOw==",
+      "version": "2.39.2",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.39.2.tgz",
+      "integrity": "sha512-7n4I6vk6DcaG9CatKLLW34RGozQZt3zKQ9TPPN6E3o33eaE5Dt8EEWfdEHXj3320BzLRIFVyG9XMb4I58n6txA==",
       "license": "MIT"
     },
     "node_modules/@rive-app/webgl2": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.39.1.tgz",
-      "integrity": "sha512-T/d2yieiQIStRatwB1G7G58tXTsXyeK91g2AhaPIGvi6SpdvQAJx7s6+ir42L4kiiTY5HeIBRXI+xueU+xzA3Q==",
+      "version": "2.39.2",
+      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.39.2.tgz",
+      "integrity": "sha512-bEp94aepIbJZpOYwRrPXtHjDmaQ9Qa9YMdpdF+UGFzer6Yzp36f+MLu7C1bagAjd0RGtGC2EH2MzbqAZvAT1Kw==",
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.39.1",
-    "@rive-app/canvas-lite": "2.39.1",
-    "@rive-app/webgl2": "2.39.1"
+    "@rive-app/canvas": "2.39.2",
+    "@rive-app/canvas-lite": "2.39.2",
+    "@rive-app/webgl2": "2.39.2"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0"


### PR DESCRIPTION
Notable changes for this release:
- fix(js): add observability for changed global VM properties
- Bringing back React releases