### PR TITLE
chore(js): bump JS runtime to 2.40.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "4.31.0",
       "license": "MIT",
       "dependencies": {
-        "@rive-app/canvas": "2.39.2",
-        "@rive-app/canvas-lite": "2.39.2",
-        "@rive-app/webgl2": "2.39.2"
+        "@rive-app/canvas": "2.40.0",
+        "@rive-app/canvas-lite": "2.40.0",
+        "@rive-app/webgl2": "2.40.0"
       },
       "devDependencies": {
         "@babel/core": "^7.18.0",
@@ -1357,21 +1357,21 @@
       }
     },
     "node_modules/@rive-app/canvas": {
-      "version": "2.39.2",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.39.2.tgz",
-      "integrity": "sha512-qC/Wc6gokYwxOD1TXX4hK9AKevLACQC04Xy0pkOseru45SzWxhqIUEWZLzM4LX5B5MQmWAbWhCVmTOTvYFTzHA==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.40.0.tgz",
+      "integrity": "sha512-TIZsYC+LoOg7NfF9pQZ5dyAQjkJdiyCisKDYqk11nc29qYzzLz79ybdyCOIBJ4dzgqsVKsC3Wtuw+YII0dg3uQ==",
       "license": "MIT"
     },
     "node_modules/@rive-app/canvas-lite": {
-      "version": "2.39.2",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.39.2.tgz",
-      "integrity": "sha512-7n4I6vk6DcaG9CatKLLW34RGozQZt3zKQ9TPPN6E3o33eaE5Dt8EEWfdEHXj3320BzLRIFVyG9XMb4I58n6txA==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.40.0.tgz",
+      "integrity": "sha512-t+ErRG98PbzZHBXsi5zuX8UytOgdDRRCQ9ksGPxR9dcjYMrU9NNydM4iLDAPLV3mJiZDJgb5bLact3YMSjlFmA==",
       "license": "MIT"
     },
     "node_modules/@rive-app/webgl2": {
-      "version": "2.39.2",
-      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.39.2.tgz",
-      "integrity": "sha512-bEp94aepIbJZpOYwRrPXtHjDmaQ9Qa9YMdpdF+UGFzer6Yzp36f+MLu7C1bagAjd0RGtGC2EH2MzbqAZvAT1Kw==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.40.0.tgz",
+      "integrity": "sha512-SmMXHvmzevS+ByvR/E3mF7llzxdHRbeTy5el8qLHSLZMYkPjfceMJg3k7lxU9m/bZICWWOOuOk/Hgl1jz6whVA==",
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.39.2",
-    "@rive-app/canvas-lite": "2.39.2",
-    "@rive-app/webgl2": "2.39.2"
+    "@rive-app/canvas": "2.40.0",
+    "@rive-app/canvas-lite": "2.40.0",
+    "@rive-app/webgl2": "2.40.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0"


### PR DESCRIPTION
When a user installs this version of the React runtime, their app bundles will inherit the JS runtime's savings (~12% reduction on Canvas, ~23% on WebGL2 on Raw WASM sizes) due to adding a Linker optimization flag in WASM builds while bumping Emscripten to 4.0.23