### PR TITLE
chore: bump JS runtime to 2.40.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "4.32.0",
       "license": "MIT",
       "dependencies": {
-        "@rive-app/canvas": "2.40.0",
-        "@rive-app/canvas-lite": "2.40.0",
-        "@rive-app/webgl2": "2.40.0"
+        "@rive-app/canvas": "2.40.1",
+        "@rive-app/canvas-lite": "2.40.1",
+        "@rive-app/webgl2": "2.40.1"
       },
       "devDependencies": {
         "@babel/core": "^7.18.0",
@@ -1357,21 +1357,21 @@
       }
     },
     "node_modules/@rive-app/canvas": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.40.0.tgz",
-      "integrity": "sha512-TIZsYC+LoOg7NfF9pQZ5dyAQjkJdiyCisKDYqk11nc29qYzzLz79ybdyCOIBJ4dzgqsVKsC3Wtuw+YII0dg3uQ==",
+      "version": "2.40.1",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas/-/canvas-2.40.1.tgz",
+      "integrity": "sha512-ea9oHIoeijZOAafE6bx6+PkiiAGjL43ZeLmhJ3bRMTsvedFvWeO0x/uCx5CY36Biu75S7Xw8hI4PryYy2b1utA==",
       "license": "MIT"
     },
     "node_modules/@rive-app/canvas-lite": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.40.0.tgz",
-      "integrity": "sha512-t+ErRG98PbzZHBXsi5zuX8UytOgdDRRCQ9ksGPxR9dcjYMrU9NNydM4iLDAPLV3mJiZDJgb5bLact3YMSjlFmA==",
+      "version": "2.40.1",
+      "resolved": "https://registry.npmjs.org/@rive-app/canvas-lite/-/canvas-lite-2.40.1.tgz",
+      "integrity": "sha512-gnlvjeI344tC9vBqYW8lV9o9g8FJPtaTq6UjmFmn4q9wLXloN/u3XqdXHsdU/5uBgCd8G6fFFQh7TqtnwzRSfA==",
       "license": "MIT"
     },
     "node_modules/@rive-app/webgl2": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.40.0.tgz",
-      "integrity": "sha512-SmMXHvmzevS+ByvR/E3mF7llzxdHRbeTy5el8qLHSLZMYkPjfceMJg3k7lxU9m/bZICWWOOuOk/Hgl1jz6whVA==",
+      "version": "2.40.1",
+      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.40.1.tgz",
+      "integrity": "sha512-O+18wvdSYs+7pqXuFYULv4L4Bg5xWsCNkQZTp3s69mOO13USfTMbuE4BGysH3QsRts7UYWCaSMsgCKteEuVphQ==",
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "homepage": "https://github.com/rive-app/rive-react#readme",
   "dependencies": {
-    "@rive-app/canvas": "2.40.0",
-    "@rive-app/canvas-lite": "2.40.0",
-    "@rive-app/webgl2": "2.40.0"
+    "@rive-app/canvas": "2.40.1",
+    "@rive-app/canvas-lite": "2.40.1",
+    "@rive-app/webgl2": "2.40.1"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0"


### PR DESCRIPTION
Bump JS runtime to 2.40.1 for fixes to focus management and semantics
- clearFocus on DOM blur
- Issue with enabling semantics on graphics with bindable artboards and referencing an instance after its been freed in memory